### PR TITLE
Move collaborators under DomainsService

### DIFF
--- a/dnsimple/collaborators.go
+++ b/dnsimple/collaborators.go
@@ -4,14 +4,6 @@ import (
 	"fmt"
 )
 
-// CollaboratorsService handles communication with the collaborator related
-// methods of the DNSimple API.
-//
-// See https://developer.dnsimple.com/v2/domains/collaborators
-type CollaboratorsService struct {
-	client *Client
-}
-
 // Collaborator represents a Collaborator in DNSimple.
 type Collaborator struct {
 	ID         int    `json:"id,omitempty"`
@@ -54,7 +46,7 @@ type CollaboratorsResponse struct {
 // ListCollaborators list the collaborators for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#list
-func (s *CollaboratorsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*CollaboratorsResponse, error) {
+func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*CollaboratorsResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
 	collaboratorsResponse := &CollaboratorsResponse{}
 
@@ -75,7 +67,7 @@ func (s *CollaboratorsService) ListCollaborators(accountID, domainIdentifier str
 // AddCollaborator adds a new collaborator to the domain in the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *CollaboratorsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*CollaboratorResponse, error) {
+func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*CollaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
 	collaboratorResponse := &CollaboratorResponse{}
 
@@ -91,7 +83,7 @@ func (s *CollaboratorsService) AddCollaborator(accountID string, domainIdentifie
 // RemoveCollaborator PERMANENTLY deletes a domain from the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *CollaboratorsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID string) (*CollaboratorResponse, error) {
+func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID string) (*CollaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
 	collaboratorResponse := &CollaboratorResponse{}
 

--- a/dnsimple/collaborators_test.go
+++ b/dnsimple/collaborators_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestCollaboratorsService_ListCollaborators(t *testing.T) {
+func TestDomainsService_ListCollaborators(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
@@ -22,35 +22,35 @@ func TestCollaboratorsService_ListCollaborators(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	collaboratorsResponse, err := client.Collaborators.ListCollaborators("1010", "example.com", nil)
+	collaboratorsResponse, err := client.Domains.ListCollaborators("1010", "example.com", nil)
 	if err != nil {
-		t.Fatalf("Collaborators.ListCollaborators() returned error: %v", err)
+		t.Fatalf("Domains.ListCollaborators() returned error: %v", err)
 	}
 
 	if want, got := (&Pagination{CurrentPage: 1, PerPage: 30, TotalPages: 1, TotalEntries: 2}), collaboratorsResponse.Pagination; !reflect.DeepEqual(want, got) {
-		t.Errorf("Collaborators.ListCollaborators() pagination expected to be %v, got %v", want, got)
+		t.Errorf("Domains.ListCollaborators() pagination expected to be %v, got %v", want, got)
 	}
 
 	collaborators := collaboratorsResponse.Data
 	if want, got := 2, len(collaborators); want != got {
-		t.Errorf("Collaborators.ListCollaborators() expected to return %v collaborators, got %v", want, got)
+		t.Errorf("Domains.ListCollaborators() expected to return %v collaborators, got %v", want, got)
 	}
 
 	if want, got := 100, collaborators[0].ID; want != got {
-		t.Fatalf("Collaborators.ListCollaborators() returned ID expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.ListCollaborators() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example.com", collaborators[0].DomainName; want != got {
-		t.Fatalf("Collaborators.ListCollaborators() returned DomainName expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.ListCollaborators() returned DomainName expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := 999, collaborators[0].UserID; want != got {
-		t.Fatalf("Collaborators.ListCollaborators() returned UserID expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.ListCollaborators() returned UserID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := false, collaborators[0].Invitation; want != got {
-		t.Fatalf("Collaborators.ListCollaborators() returned Invitation expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.ListCollaborators() returned Invitation expected to be `%v`, got `%v`", want, got)
 	}
 }
 
-func TestCollaboratorsService_ListCollaborators_WithOptions(t *testing.T) {
+func TestDomainsService_ListCollaborators_WithOptions(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
@@ -63,13 +63,13 @@ func TestCollaboratorsService_ListCollaborators_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Collaborators.ListCollaborators("1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Domains.ListCollaborators("1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
-		t.Fatalf("Collaborators.ListCollaborators() returned error: %v", err)
+		t.Fatalf("Domains.ListCollaborators() returned error: %v", err)
 	}
 }
 
-func TestCollaboratorsService_AddCollaborator(t *testing.T) {
+func TestDomainsService_AddCollaborator(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
@@ -90,27 +90,27 @@ func TestCollaboratorsService_AddCollaborator(t *testing.T) {
 	domainID := "example.com"
 	collaboratorAttributes := CollaboratorAttributes{Email: "existing-user@example.com"}
 
-	collaboratorResponse, err := client.Collaborators.AddCollaborator(accountID, domainID, collaboratorAttributes)
+	collaboratorResponse, err := client.Domains.AddCollaborator(accountID, domainID, collaboratorAttributes)
 	if err != nil {
-		t.Fatalf("Collaborators.AddCollaborator() returned error: %v", err)
+		t.Fatalf("Domains.AddCollaborator() returned error: %v", err)
 	}
 
 	collaborator := collaboratorResponse.Data
 	if want, got := 100, collaborator.ID; want != got {
-		t.Fatalf("Collaborators.AddCollaborator() returned ID expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.AddCollaborator() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example.com", collaborator.DomainName; want != got {
-		t.Fatalf("Collaborators.AddCollaborator() returned DomainName expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.AddCollaborator() returned DomainName expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := false, collaborator.Invitation; want != got {
-		t.Fatalf("Collaborators.AddCollaborator() returned Invitation expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.AddCollaborator() returned Invitation expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "2016-10-07T08:53:41.643Z", collaborator.AcceptedAt; want != got {
-		t.Fatalf("Collaborators.AddCollaborator() returned AcceptedAt expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.AddCollaborator() returned AcceptedAt expected to be `%v`, got `%v`", want, got)
 	}
 }
 
-func TestCollaboratorsService_AddNonExistingCollaborator(t *testing.T) {
+func TestDomainsService_AddNonExistingCollaborator(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
@@ -131,23 +131,23 @@ func TestCollaboratorsService_AddNonExistingCollaborator(t *testing.T) {
 	domainID := "example.com"
 	collaboratorAttributes := CollaboratorAttributes{Email: "invited-user@example.com"}
 
-	collaboratorResponse, err := client.Collaborators.AddCollaborator(accountID, domainID, collaboratorAttributes)
+	collaboratorResponse, err := client.Domains.AddCollaborator(accountID, domainID, collaboratorAttributes)
 	if err != nil {
-		t.Fatalf("Collaborators.AddCollaborator() returned error: %v", err)
+		t.Fatalf("Domains.AddCollaborator() returned error: %v", err)
 	}
 
 	collaborator := collaboratorResponse.Data
 	if want, got := 101, collaborator.ID; want != got {
-		t.Fatalf("Collaborators.AddCollaborator() returned ID expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.AddCollaborator() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example.com", collaborator.DomainName; want != got {
-		t.Fatalf("Collaborators.AddCollaborator() returned DomainName expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.AddCollaborator() returned DomainName expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := true, collaborator.Invitation; want != got {
-		t.Fatalf("Collaborators.AddCollaborator() returned Invitation expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.AddCollaborator() returned Invitation expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "", collaborator.AcceptedAt; want != got {
-		t.Fatalf("Collaborators.AddCollaborator() returned AcceptedAt expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Domains.AddCollaborator() returned AcceptedAt expected to be `%v`, got `%v`", want, got)
 	}
 }
 
@@ -169,8 +169,8 @@ func TestDomainsService_RemoveCollaborator(t *testing.T) {
 	domainID := "example.com"
 	contactID := "100"
 
-	_, err := client.Collaborators.RemoveCollaborator(accountID, domainID, contactID)
+	_, err := client.Domains.RemoveCollaborator(accountID, domainID, contactID)
 	if err != nil {
-		t.Fatalf("Collaborators.RemoveCollaborator() returned error: %v", err)
+		t.Fatalf("Domains.RemoveCollaborator() returned error: %v", err)
 	}
 }

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -55,7 +55,6 @@ type Client struct {
 	Identity          *IdentityService
 	Accounts          *AccountsService
 	Certificates      *CertificatesService
-	Collaborators     *CollaboratorsService
 	Contacts          *ContactsService
 	Domains           *DomainsService
 	Oauth             *OauthService
@@ -92,7 +91,6 @@ func NewClient(credentials Credentials) *Client {
 	c.Identity = &IdentityService{client: c}
 	c.Accounts = &AccountsService{client: c}
 	c.Certificates = &CertificatesService{client: c}
-	c.Collaborators = &CollaboratorsService{client: c}
 	c.Contacts = &ContactsService{client: c}
 	c.Domains = &DomainsService{client: c}
 	c.Oauth = &OauthService{client: c}


### PR DESCRIPTION
This is a proposal to move collaborators API from its own service `client.Collaborators.ListCollaborators` under `client.Domains.ListCollaborators`.

Collaborator is a concept that only has its meaning under a domain. See: https://developer.dnsimple.com/v2/domains/collaborators/

Ref: https://github.com/dnsimple/dnsimple-ruby/pull/137#issuecomment-261963160
Ref: https://github.com/dnsimple/dnsimple-ruby/pull/137#issuecomment-261967523

---

/cc @weppos @aeden for review