### PR TITLE
Update registration, transfer, renewal responses

### DIFF
--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -94,10 +94,23 @@ type DomainTransferRequest struct {
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 }
 
+// DomainRenewal represents the result of a domain renewal call.
+type DomainTransfer struct {
+	ID           int    `json:"id"`
+	DomainID     int    `json:"domain_id"`
+	RegistrantID int    `json:"registrant_id"`
+	State        string `json:"state"`
+	AutoRenew    bool   `json:"auto_renew"`
+	PrivateWhois bool   `json:"private_whois"`
+	PremiumPrice int    `json:"premium_price"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
 // DomainTransferResponse represents a response from an API method that results in a domain transfer.
 type DomainTransferResponse struct {
 	Response
-	Data *Domain `json:"data"`
+	Data *DomainTransfer `json:"data"`
 }
 
 // TransferDomain transfers a domain name.

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -54,10 +54,24 @@ type DomainRegisterRequest struct {
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 }
 
+// DomainRegistration represents the result of a domain renewal call.
+type DomainRegistration struct {
+	ID           int    `json:"id"`
+	DomainID     int    `json:"domain_id"`
+	RegistrantID int    `json:"registrant_id"`
+	Period       int    `json:"period"`
+	State        string `json:"state"`
+	AutoRenew    bool   `json:"auto_renew"`
+	PrivateWhois bool   `json:"private_whois"`
+	PremiumPrice int    `json:"premium_price"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
 // DomainRegistrationResponse represents a response from an API method that results in a domain registration.
 type DomainRegistrationResponse struct {
 	Response
-	Data *Domain `json:"data"`
+	Data *DomainRegistration `json:"data"`
 }
 
 // RegisterDomain registers a domain name.
@@ -94,7 +108,7 @@ type DomainTransferRequest struct {
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 }
 
-// DomainRenewal represents the result of a domain renewal call.
+// DomainTransfer represents the result of a domain renewal call.
 type DomainTransfer struct {
 	ID           int    `json:"id"`
 	DomainID     int    `json:"domain_id"`

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -63,7 +63,7 @@ type DomainRegistration struct {
 	State        string `json:"state"`
 	AutoRenew    bool   `json:"auto_renew"`
 	PrivateWhois bool   `json:"private_whois"`
-	PremiumPrice int    `json:"premium_price"`
+	PremiumPrice string `json:"premium_price"`
 	CreatedAt    string `json:"created_at,omitempty"`
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
@@ -116,7 +116,7 @@ type DomainTransfer struct {
 	State        string `json:"state"`
 	AutoRenew    bool   `json:"auto_renew"`
 	PrivateWhois bool   `json:"private_whois"`
-	PremiumPrice int    `json:"premium_price"`
+	PremiumPrice string `json:"premium_price"`
 	CreatedAt    string `json:"created_at,omitempty"`
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
@@ -181,7 +181,7 @@ type DomainRenewal struct {
 	Period       int    `json:"period"`
 	State        string `json:"state"`
 	PrivateWhois bool   `json:"private_whois"`
-	PremiumPrice int    `json:"premium_price"`
+	PremiumPrice string `json:"premium_price"`
 	CreatedAt    string `json:"created_at,omitempty"`
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -179,6 +179,7 @@ type DomainRenewal struct {
 	ID           int    `json:"id"`
 	DomainID     int    `json:"domain_id"`
 	Period       int    `json:"period"`
+	State        string `json:"state"`
 	PrivateWhois bool   `json:"private_whois"`
 	PremiumPrice int    `json:"premium_price"`
 	CreatedAt    string `json:"created_at,omitempty"`

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -19,7 +19,7 @@ type DomainCheck struct {
 	Premium   bool   `json:"premium"`
 }
 
-// DomainCheckResponse represents a response from the domain check.
+// DomainCheckResponse represents a response from a domain check request.
 type DomainCheckResponse struct {
 	Response
 	Data *DomainCheck `json:"data"`
@@ -147,10 +147,21 @@ type DomainRenewRequest struct {
 	Period int `json:"period"`
 }
 
-// DomainRenewalResponse represents a response from an API method that results in a domain renewal.
+// DomainRenewal represents the result of a domain renewal call.
+type DomainRenewal struct {
+	ID           int    `json:"id"`
+	DomainID     int    `json:"domain_id"`
+	Period       int    `json:"period"`
+	PrivateWhois bool   `json:"private_whois"`
+	PremiumPrice int    `json:"premium_price"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+// DomainRenewalResponse represents a response from an API method that returns a domain renewal.
 type DomainRenewalResponse struct {
 	Response
-	Data *Domain `json:"data"`
+	Data *DomainRenewal `json:"data"`
 }
 
 // RenewDomain renews a domain name.

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -134,16 +134,16 @@ func TestRegistrarService_RenewDomain(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	registrationResponse, err := client.Registrar.RenewDomain("1010", "example.com", nil)
+	renewalResponse, err := client.Registrar.RenewDomain("1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("Registrar.Renew() returned error: %v", err)
 	}
 
-	domain := registrationResponse.Data
-	if want, got := 1, domain.ID; want != got {
-		t.Fatalf("Registrar.Renew() returned ID expected to be `%v`, got `%v`", want, got)
+	renewal := renewalResponse.Data
+	if want, got := 1, renewal.ID; want != got {
+		t.Fatalf("Registrar.RenewDomain() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := "example.com", domain.Name; want != got {
-		t.Fatalf("Registrar.Renew() returned Name expected to be `%v`, got `%v`", want, got)
+	if want, got := 999, renewal.DomainID; want != got {
+		t.Fatalf("Registrar.RenewDomain() returned DomainID expected to be `%v`, got `%v`", want, got)
 	}
 }

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -52,15 +52,15 @@ func TestRegistrarService_RegisterDomain(t *testing.T) {
 
 	registrationResponse, err := client.Registrar.RegisterDomain("1010", "example.com", registerRequest)
 	if err != nil {
-		t.Fatalf("Registrar.Register() returned error: %v", err)
+		t.Fatalf("Registrar.RegisterDomain() returned error: %v", err)
 	}
 
-	domain := registrationResponse.Data
-	if want, got := 1, domain.ID; want != got {
-		t.Fatalf("Registrar.Register() returned ID expected to be `%v`, got `%v`", want, got)
+	registration := registrationResponse.Data
+	if want, got := 1, registration.ID; want != got {
+		t.Fatalf("Registrar.RegisterDomain() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := "example.com", domain.Name; want != got {
-		t.Fatalf("Registrar.Register() returned Name expected to be `%v`, got `%v`", want, got)
+	if want, got := 999, registration.DomainID; want != got {
+		t.Fatalf("Registrar.RegisterDomain() returned Name expected to be `%v`, got `%v`", want, got)
 	}
 }
 

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -85,15 +85,15 @@ func TestRegistrarService_TransferDomain(t *testing.T) {
 
 	transferResponse, err := client.Registrar.TransferDomain("1010", "example.com", transferRequest)
 	if err != nil {
-		t.Fatalf("Registrar.Transfer() returned error: %v", err)
+		t.Fatalf("Registrar.TransferDomain() returned error: %v", err)
 	}
 
-	domain := transferResponse.Data
-	if want, got := 1, domain.ID; want != got {
-		t.Fatalf("Registrar.Transfer() returned ID expected to be `%v`, got `%v`", want, got)
+	transfer := transferResponse.Data
+	if want, got := 1, transfer.ID; want != got {
+		t.Fatalf("Registrar.TransferDomain() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := "example.com", domain.Name; want != got {
-		t.Fatalf("Registrar.Transfer() returned Name expected to be `%v`, got `%v`", want, got)
+	if want, got := 999, transfer.DomainID; want != got {
+		t.Fatalf("Registrar.TransferDomain() returned Name expected to be `%v`, got `%v`", want, got)
 	}
 }
 
@@ -136,7 +136,7 @@ func TestRegistrarService_RenewDomain(t *testing.T) {
 
 	renewalResponse, err := client.Registrar.RenewDomain("1010", "example.com", nil)
 	if err != nil {
-		t.Fatalf("Registrar.Renew() returned error: %v", err)
+		t.Fatalf("Registrar.RenewDomain() returned error: %v", err)
 	}
 
 	renewal := renewalResponse.Data

--- a/fixtures.http/registerDomain/success.http
+++ b/fixtures.http/registerDomain/success.http
@@ -1,17 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Sat, 16 Jan 2016 16:09:02 GMT
+Date: Fri, 09 Dec 2016 19:35:38 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 201 Created
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3965
-X-RateLimit-Reset: 1452960541
-ETag: W/"e034ef9fb32487cf4dc034050ba846c5"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2396
+X-RateLimit-Reset: 1481315246
+ETag: W/"440b25022ab55cd8e84be64356bfd7d9"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 8b378ee7-d8fa-4459-a1b0-a18bfd2354bb
-X-Runtime: 13.365767
+X-Request-Id: aac22ee4-31d7-4d71-ad3d-d0004f5cf370
+X-Runtime: 11.906207
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":2,"name":"example.com","unicode_name":"example.com","token":"cc8h1jP8bDLw5rXycL16k8BivcGiT6K9","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2017-01-16","created_at":"2016-01-16T16:08:50.649Z","updated_at":"2016-01-16T16:09:01.161Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"private_whois":false,"premium_price":null,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}

--- a/fixtures.http/renewDomain/error-tooearly.http
+++ b/fixtures.http/renewDomain/error-tooearly.http
@@ -1,0 +1,15 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 15 Feb 2016 15:06:35 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 400 Bad Request
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3998
+X-RateLimit-Reset: 1455552316
+Cache-Control: no-cache
+X-Request-Id: 0c1507d3-4c03-4ba3-b2bd-b0cabf021ed8
+X-Runtime: 0.256476
+
+{"message":"example.com may not be renewed at this time","errors":{}}

--- a/fixtures.http/renewDomain/success.http
+++ b/fixtures.http/renewDomain/success.http
@@ -1,17 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Mon, 15 Feb 2016 15:19:24 GMT
+Date: Fri, 09 Dec 2016 19:46:57 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 201 Created
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3996
-X-RateLimit-Reset: 1455552316
-ETag: W/"3ee240b342a641fbc69f9c35fa77b53f"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: f888665c-8fcc-4ff1-a954-8ce7d7e19af6
-X-Runtime: 3.506408
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":2,"name":"example.com","unicode_name":"example.com","token":"domain-token","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2018-01-16","created_at":"2016-01-16T16:08:50.649Z","updated_at":"2016-02-15T15:19:24.689Z"}}
+{"data":{"id":1,"domain_id":999,"period":1,"state":"new","private_whois":false,"premium_price":null,"created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}

--- a/fixtures.http/transferDomain/error-indnsimple.http
+++ b/fixtures.http/transferDomain/error-indnsimple.http
@@ -1,0 +1,15 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Sun, 21 Feb 2016 13:11:54 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 400 Bad Request
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3996
+X-RateLimit-Reset: 1456063541
+Cache-Control: no-cache
+X-Request-Id: 15d2e302-e835-4dda-9652-03d8962280ae
+X-Runtime: 0.994068
+
+{"message":"The domain google.com is already in DNSimple and cannot be added"}

--- a/fixtures.http/transferDomain/error-missing-authcode.http
+++ b/fixtures.http/transferDomain/error-missing-authcode.http
@@ -1,0 +1,15 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Sun, 21 Feb 2016 13:11:11 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 400 Bad Request
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3997
+X-RateLimit-Reset: 1456063540
+Cache-Control: no-cache
+X-Request-Id: d7a0eb63-77eb-4488-bc55-c129ed8fe192
+X-Runtime: 11.912567
+
+{"message":"Validation failed","errors":{"base":["You must provide an authorization code for the domain"]}}

--- a/fixtures.http/transferDomain/success.http
+++ b/fixtures.http/transferDomain/success.http
@@ -1,17 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Sun, 21 Feb 2016 13:32:02 GMT
+Date: Fri, 09 Dec 2016 19:43:43 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 201 Created
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3992
-X-RateLimit-Reset: 1456063540
-ETag: W/"68e1aa1046c3f33f2ad796befc2b9f5b"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2395
+X-RateLimit-Reset: 1481315246
+ETag: W/"e58e7ac3ad9e30162c5098f29f208066"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: c3401f82-d570-4998-a614-245f3a7677ba
-X-Runtime: 15.045124
+X-Request-Id: 0d00c622-9fc8-406a-93cb-d2c5d6ecd6b4
+X-Runtime: 6.483160
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":2,"name":"example.com","unicode_name":"example.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2016-02-21T13:31:58.745Z","updated_at":"2016-02-21T13:31:58.745Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"private_whois":false,"premium_price":null,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}


### PR DESCRIPTION
This PR update the response from a register/transfer/renew domain request, as these API calls are now return representation of a Transfer, Registration, and Renewal instead of a Domain.

See dnsimple/dnsimple-developer#111