### PR TITLE
Do not export response types

### DIFF
--- a/dnsimple/accounts.go
+++ b/dnsimple/accounts.go
@@ -16,8 +16,8 @@ type Account struct {
 	UpdatedAt      string `json:"updated_at,omitempty"`
 }
 
-// AccountsResponse represents a response from an API method that returns a collection of Account struct.
-type AccountsResponse struct {
+// accountsResponse represents a response from an API method that returns a collection of Account struct.
+type accountsResponse struct {
 	Response
 	Data []Account `json:"data"`
 }
@@ -25,9 +25,9 @@ type AccountsResponse struct {
 // ListAccounts list the accounts for an user.
 //
 // See https://developer.dnsimple.com/v2/accounts/#list
-func (s *AccountsService) ListAccounts(options *ListOptions) (*AccountsResponse, error) {
+func (s *AccountsService) ListAccounts(options *ListOptions) (*accountsResponse, error) {
 	path := versioned("/accounts")
-	accountsResponse := &AccountsResponse{}
+	accountsResponse := &accountsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {

--- a/dnsimple/authentication.go
+++ b/dnsimple/authentication.go
@@ -54,7 +54,6 @@ func (c *httpBasicCredentials) basicAuth(username, password string) string {
 }
 
 // OAuth token authentication
-
 type oauthTokenCredentials struct {
 	oauthToken string
 }

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -45,20 +45,20 @@ func certificatePath(accountID, domainIdentifier, certificateID string) (path st
 	return
 }
 
-// CertificateResponse represents a response from an API method that returns a Certificate struct.
-type CertificateResponse struct {
+// certificateResponse represents a response from an API method that returns a Certificate struct.
+type certificateResponse struct {
 	Response
 	Data *Certificate `json:"data"`
 }
 
-// CertificateBundleResponse represents a response from an API method that returns a CertificatBundle struct.
-type CertificateBundleResponse struct {
+// certificateBundleResponse represents a response from an API method that returns a CertificatBundle struct.
+type certificateBundleResponse struct {
 	Response
 	Data *CertificateBundle `json:"data"`
 }
 
-// CertificatesResponse represents a response from an API method that returns a collection of Certificate struct.
-type CertificatesResponse struct {
+// certificatesResponse represents a response from an API method that returns a collection of Certificate struct.
+type certificatesResponse struct {
 	Response
 	Data []Certificate `json:"data"`
 }
@@ -66,9 +66,9 @@ type CertificatesResponse struct {
 // ListCertificates list the certificates for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/certificates#list
-func (s *CertificatesService) ListCertificates(accountID, domainIdentifier string, options *ListOptions) (*CertificatesResponse, error) {
+func (s *CertificatesService) ListCertificates(accountID, domainIdentifier string, options *ListOptions) (*certificatesResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, ""))
-	certificatesResponse := &CertificatesResponse{}
+	certificatesResponse := &certificatesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -87,9 +87,9 @@ func (s *CertificatesService) ListCertificates(accountID, domainIdentifier strin
 // GetCertificate fetches the certificate.
 //
 // See https://developer.dnsimple.com/v2/domains/certificates#get
-func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string, certificateID int) (*CertificateResponse, error) {
+func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string, certificateID int) (*certificateResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)))
-	certificateResponse := &CertificateResponse{}
+	certificateResponse := &certificateResponse{}
 
 	resp, err := s.client.get(path, certificateResponse)
 	if err != nil {
@@ -104,9 +104,9 @@ func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string,
 // as well the root certificate and the intermediate chain.
 //
 // See https://developer.dnsimple.com/v2/domains/certificates#download
-func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier string, certificateID int) (*CertificateBundleResponse, error) {
+func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier string, certificateID int) (*certificateBundleResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + "/download")
-	certificateBundleResponse := &CertificateBundleResponse{}
+	certificateBundleResponse := &certificateBundleResponse{}
 
 	resp, err := s.client.get(path, certificateBundleResponse)
 	if err != nil {
@@ -120,9 +120,9 @@ func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier st
 // GetCertificatePrivateKey fetches the certificate private key.
 //
 // See https://developer.dnsimple.com/v2/domains/certificates#get-private-key
-func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifier string, certificateID int) (*CertificateBundleResponse, error) {
+func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifier string, certificateID int) (*certificateBundleResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + "/private_key")
-	certificateBundleResponse := &CertificateBundleResponse{}
+	certificateBundleResponse := &certificateBundleResponse{}
 
 	resp, err := s.client.get(path, certificateBundleResponse)
 	if err != nil {

--- a/dnsimple/collaborators.go
+++ b/dnsimple/collaborators.go
@@ -17,11 +17,6 @@ type Collaborator struct {
 	AcceptedAt string `json:"accepted_at,omitempty"`
 }
 
-// CollaboratorAttributes represents Collaborator attributes for AddCollaborator operation.
-type CollaboratorAttributes struct {
-	Email string `json:"email,omitempty"`
-}
-
 func collaboratorPath(accountID, domainIdentifier, collaboratorID string) (path string) {
 	path = fmt.Sprintf("%v/collaborators", domainPath(accountID, domainIdentifier))
 	if collaboratorID != "" {
@@ -30,14 +25,19 @@ func collaboratorPath(accountID, domainIdentifier, collaboratorID string) (path 
 	return
 }
 
-// CollaboratorResponse represents a response from an API method that returns a Collaborator struct.
-type CollaboratorResponse struct {
+// CollaboratorAttributes represents Collaborator attributes for AddCollaborator operation.
+type CollaboratorAttributes struct {
+	Email string `json:"email,omitempty"`
+}
+
+// collaboratorResponse represents a response from an API method that returns a Collaborator struct.
+type collaboratorResponse struct {
 	Response
 	Data *Collaborator `json:"data"`
 }
 
-// CollaboratorsResponse represents a response from an API method that returns a collection of Collaborator struct.
-type CollaboratorsResponse struct {
+// collaboratorsResponse represents a response from an API method that returns a collection of Collaborator struct.
+type collaboratorsResponse struct {
 	Response
 	Data []Collaborator `json:"data"`
 }
@@ -45,9 +45,9 @@ type CollaboratorsResponse struct {
 // ListCollaborators list the collaborators for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#list
-func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*CollaboratorsResponse, error) {
+func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*collaboratorsResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
-	collaboratorsResponse := &CollaboratorsResponse{}
+	collaboratorsResponse := &collaboratorsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -66,9 +66,9 @@ func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, o
 // AddCollaborator adds a new collaborator to the domain in the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*CollaboratorResponse, error) {
+func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*collaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
-	collaboratorResponse := &CollaboratorResponse{}
+	collaboratorResponse := &collaboratorResponse{}
 
 	resp, err := s.client.post(path, attributes, collaboratorResponse)
 	if err != nil {
@@ -82,9 +82,9 @@ func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier stri
 // RemoveCollaborator PERMANENTLY deletes a domain from the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID string) (*CollaboratorResponse, error) {
+func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID string) (*collaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
-	collaboratorResponse := &CollaboratorResponse{}
+	collaboratorResponse := &collaboratorResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -42,14 +42,14 @@ func contactPath(accountID string, contactID int) (path string) {
 	return
 }
 
-// ContactResponse represents a response from an API method that returns a Contact struct.
-type ContactResponse struct {
+// contactResponse represents a response from an API method that returns a Contact struct.
+type contactResponse struct {
 	Response
 	Data *Contact `json:"data"`
 }
 
-// ContactsResponse represents a response from an API method that returns a collection of Contact struct.
-type ContactsResponse struct {
+// contactsResponse represents a response from an API method that returns a collection of Contact struct.
+type contactsResponse struct {
 	Response
 	Data []Contact `json:"data"`
 }
@@ -57,9 +57,9 @@ type ContactsResponse struct {
 // ListContacts list the contacts for an account.
 //
 // See https://developer.dnsimple.com/v2/contacts/#list
-func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (*ContactsResponse, error) {
+func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (*contactsResponse, error) {
 	path := versioned(contactPath(accountID, 0))
-	contactsResponse := &ContactsResponse{}
+	contactsResponse := &contactsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -78,9 +78,9 @@ func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (
 // CreateContact creates a new contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#create
-func (s *ContactsService) CreateContact(accountID string, contactAttributes Contact) (*ContactResponse, error) {
+func (s *ContactsService) CreateContact(accountID string, contactAttributes Contact) (*contactResponse, error) {
 	path := versioned(contactPath(accountID, 0))
-	contactResponse := &ContactResponse{}
+	contactResponse := &contactResponse{}
 
 	resp, err := s.client.post(path, contactAttributes, contactResponse)
 	if err != nil {
@@ -94,9 +94,9 @@ func (s *ContactsService) CreateContact(accountID string, contactAttributes Cont
 // GetContact fetches a contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#get
-func (s *ContactsService) GetContact(accountID string, contactID int) (*ContactResponse, error) {
+func (s *ContactsService) GetContact(accountID string, contactID int) (*contactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
-	contactResponse := &ContactResponse{}
+	contactResponse := &contactResponse{}
 
 	resp, err := s.client.get(path, contactResponse)
 	if err != nil {
@@ -110,9 +110,9 @@ func (s *ContactsService) GetContact(accountID string, contactID int) (*ContactR
 // UpdateContact updates a contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#update
-func (s *ContactsService) UpdateContact(accountID string, contactID int, contactAttributes Contact) (*ContactResponse, error) {
+func (s *ContactsService) UpdateContact(accountID string, contactID int, contactAttributes Contact) (*contactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
-	contactResponse := &ContactResponse{}
+	contactResponse := &contactResponse{}
 
 	resp, err := s.client.patch(path, contactAttributes, contactResponse)
 	if err != nil {
@@ -126,9 +126,9 @@ func (s *ContactsService) UpdateContact(accountID string, contactID int, contact
 // DeleteContact PERMANENTLY deletes a contact from the account.
 //
 // See https://developer.dnsimple.com/v2/contacts/#delete
-func (s *ContactsService) DeleteContact(accountID string, contactID int) (*ContactResponse, error) {
+func (s *ContactsService) DeleteContact(accountID string, contactID int) (*contactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
-	contactResponse := &ContactResponse{}
+	contactResponse := &contactResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -28,6 +28,26 @@ type Domain struct {
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
+func domainPath(accountID string, domainIdentifier string) (path string) {
+	path = fmt.Sprintf("/%v/domains", accountID)
+	if domainIdentifier != "" {
+		path += fmt.Sprintf("/%v", domainIdentifier)
+	}
+	return
+}
+
+// domainResponse represents a response from an API method that returns a Domain struct.
+type domainResponse struct {
+	Response
+	Data *Domain `json:"data"`
+}
+
+// domainsResponse represents a response from an API method that returns a collection of Domain struct.
+type domainsResponse struct {
+	Response
+	Data []Domain `json:"data"`
+}
+
 // DomainListOptions specifies the optional parameters you can provide
 // to customize the DomainsService.ListDomains method.
 type DomainListOptions struct {
@@ -40,32 +60,12 @@ type DomainListOptions struct {
 	ListOptions
 }
 
-// DomainResponse represents a response from an API method that returns a Domain struct.
-type DomainResponse struct {
-	Response
-	Data *Domain `json:"data"`
-}
-
-// DomainsResponse represents a response from an API method that returns a collection of Domain struct.
-type DomainsResponse struct {
-	Response
-	Data []Domain `json:"data"`
-}
-
-func domainPath(accountID string, domainIdentifier string) (path string) {
-	path = fmt.Sprintf("/%v/domains", accountID)
-	if domainIdentifier != "" {
-		path += fmt.Sprintf("/%v", domainIdentifier)
-	}
-	return
-}
-
 // ListDomains lists the domains for an account.
 //
 // See https://developer.dnsimple.com/v2/domains/#list
-func (s *DomainsService) ListDomains(accountID string, options *DomainListOptions) (*DomainsResponse, error) {
+func (s *DomainsService) ListDomains(accountID string, options *DomainListOptions) (*domainsResponse, error) {
 	path := versioned(domainPath(accountID, ""))
-	domainsResponse := &DomainsResponse{}
+	domainsResponse := &domainsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -84,9 +84,9 @@ func (s *DomainsService) ListDomains(accountID string, options *DomainListOption
 // CreateDomain creates a new domain in the account.
 //
 // See https://developer.dnsimple.com/v2/domains/#create
-func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain) (*DomainResponse, error) {
+func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain) (*domainResponse, error) {
 	path := versioned(domainPath(accountID, ""))
-	domainResponse := &DomainResponse{}
+	domainResponse := &domainResponse{}
 
 	resp, err := s.client.post(path, domainAttributes, domainResponse)
 	if err != nil {
@@ -100,9 +100,9 @@ func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain)
 // GetDomain fetches a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/#get
-func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*DomainResponse, error) {
+func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*domainResponse, error) {
 	path := versioned(domainPath(accountID, domainIdentifier))
-	domainResponse := &DomainResponse{}
+	domainResponse := &domainResponse{}
 
 	resp, err := s.client.get(path, domainResponse)
 	if err != nil {
@@ -116,9 +116,9 @@ func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*
 // DeleteDomain PERMANENTLY deletes a domain from the account.
 //
 // See https://developer.dnsimple.com/v2/domains/#delete
-func (s *DomainsService) DeleteDomain(accountID string, domainIdentifier string) (*DomainResponse, error) {
+func (s *DomainsService) DeleteDomain(accountID string, domainIdentifier string) (*domainResponse, error) {
 	path := versioned(domainPath(accountID, domainIdentifier))
-	domainResponse := &DomainResponse{}
+	domainResponse := &domainResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {
@@ -132,9 +132,9 @@ func (s *DomainsService) DeleteDomain(accountID string, domainIdentifier string)
 // ResetDomainToken resets the domain token.
 //
 // See https://developer.dnsimple.com/v2/domains/#reset-token
-func (s *DomainsService) ResetDomainToken(accountID string, domainIdentifier string) (*DomainResponse, error) {
+func (s *DomainsService) ResetDomainToken(accountID string, domainIdentifier string) (*domainResponse, error) {
 	path := versioned(domainPath(accountID, domainIdentifier) + "/token")
-	domainResponse := &DomainResponse{}
+	domainResponse := &domainResponse{}
 
 	resp, err := s.client.post(path, nil, domainResponse)
 	if err != nil {

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -14,18 +14,6 @@ type EmailForward struct {
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-// EmailForwardResponse represents a response from an API method that returns an EmailForward struct.
-type EmailForwardResponse struct {
-	Response
-	Data *EmailForward `json:"data"`
-}
-
-// EmailForwardsResponse represents a response from an API method that returns a collection of EmailForward struct.
-type EmailForwardsResponse struct {
-	Response
-	Data []EmailForward `json:"data"`
-}
-
 func emailForwardPath(accountID string, domainIdentifier string, forwardID int) (path string) {
 	path = fmt.Sprintf("%v/email_forwards", domainPath(accountID, domainIdentifier))
 	if forwardID != 0 {
@@ -34,12 +22,24 @@ func emailForwardPath(accountID string, domainIdentifier string, forwardID int) 
 	return
 }
 
+// emailForwardResponse represents a response from an API method that returns an EmailForward struct.
+type emailForwardResponse struct {
+	Response
+	Data *EmailForward `json:"data"`
+}
+
+// emailForwardsResponse represents a response from an API method that returns a collection of EmailForward struct.
+type emailForwardsResponse struct {
+	Response
+	Data []EmailForward `json:"data"`
+}
+
 // ListEmailForwards lists the email forwards for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#list
-func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier string, options *ListOptions) (*EmailForwardsResponse, error) {
+func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier string, options *ListOptions) (*emailForwardsResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier , 0))
-	forwardsResponse := &EmailForwardsResponse{}
+	forwardsResponse := &emailForwardsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -58,9 +58,9 @@ func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier st
 // CreateEmailForward creates a new email forward.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#create
-func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier string, forwardAttributes EmailForward) (*EmailForwardResponse, error) {
+func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier string, forwardAttributes EmailForward) (*emailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
-	forwardResponse := &EmailForwardResponse{}
+	forwardResponse := &emailForwardResponse{}
 
 	resp, err := s.client.post(path, forwardAttributes, forwardResponse)
 	if err != nil {
@@ -74,9 +74,9 @@ func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier s
 // GetEmailForward fetches an email forward.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#get
-func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier string, forwardID int) (*EmailForwardResponse, error) {
+func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier string, forwardID int) (*emailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
-	forwardResponse := &EmailForwardResponse{}
+	forwardResponse := &emailForwardResponse{}
 
 	resp, err := s.client.get(path, forwardResponse)
 	if err != nil {
@@ -90,9 +90,9 @@ func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier stri
 // DeleteEmailForward PERMANENTLY deletes an email forward from the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#delete
-func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier string, forwardID int) (*EmailForwardResponse, error) {
+func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier string, forwardID int) (*emailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
-	forwardResponse := &EmailForwardResponse{}
+	forwardResponse := &emailForwardResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/domains_pushes.go
+++ b/dnsimple/domains_pushes.go
@@ -15,24 +15,6 @@ type DomainPush struct {
 	AcceptedAt string `json:"accepted_at,omitempty"`
 }
 
-// DomainPushAttributes represent a domain push payload (see initiate).
-type DomainPushAttributes struct {
-	NewAccountEmail string `json:"new_account_email,omitempty"`
-	ContactID       string `json:"contact_id,omitempty"`
-}
-
-// DomainPushResponse represents a response from an API method that returns a DomainPush struct.
-type DomainPushResponse struct {
-	Response
-	Data *DomainPush `json:"data"`
-}
-
-// DomainPushesResponse represents a response from an API method that returns a collection of DomainPush struct.
-type DomainPushesResponse struct {
-	Response
-	Data []DomainPush `json:"data"`
-}
-
 func domainPushPath(accountID string, pushID int) (path string) {
 	path = fmt.Sprintf("/%v/pushes", accountID)
 	if pushID != 0 {
@@ -41,12 +23,30 @@ func domainPushPath(accountID string, pushID int) (path string) {
 	return
 }
 
+// domainPushResponse represents a response from an API method that returns a DomainPush struct.
+type domainPushResponse struct {
+	Response
+	Data *DomainPush `json:"data"`
+}
+
+// domainPushesResponse represents a response from an API method that returns a collection of DomainPush struct.
+type domainPushesResponse struct {
+	Response
+	Data []DomainPush `json:"data"`
+}
+
+// DomainPushAttributes represent a domain push payload (see initiate).
+type DomainPushAttributes struct {
+	NewAccountEmail string `json:"new_account_email,omitempty"`
+	ContactID       string `json:"contact_id,omitempty"`
+}
+
 // InitiatePush initiate a new domain push.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#initiate
-func (s *DomainsService) InitiatePush(accountID string, domainID string, pushAttributes DomainPushAttributes) (*DomainPushResponse, error) {
+func (s *DomainsService) InitiatePush(accountID string, domainID string, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/pushes", domainPath(accountID, domainID)))
-	pushResponse := &DomainPushResponse{}
+	pushResponse := &domainPushResponse{}
 
 	resp, err := s.client.post(path, pushAttributes, pushResponse)
 	if err != nil {
@@ -60,9 +60,9 @@ func (s *DomainsService) InitiatePush(accountID string, domainID string, pushAtt
 // ListPushes lists the pushes for an account.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#list
-func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*DomainPushesResponse, error) {
+func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*domainPushesResponse, error) {
 	path := versioned(domainPushPath(accountID, 0))
-	pushesResponse := &DomainPushesResponse{}
+	pushesResponse := &domainPushesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -81,9 +81,9 @@ func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*Do
 // AcceptPush accept a push for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#accept
-func (s *DomainsService) AcceptPush(accountID string, pushID int, pushAttributes DomainPushAttributes) (*DomainPushResponse, error) {
+func (s *DomainsService) AcceptPush(accountID string, pushID int, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
 	path := versioned(domainPushPath(accountID, pushID))
-	pushResponse := &DomainPushResponse{}
+	pushResponse := &domainPushResponse{}
 
 	resp, err := s.client.post(path, pushAttributes, nil)
 	if err != nil {
@@ -97,9 +97,9 @@ func (s *DomainsService) AcceptPush(accountID string, pushID int, pushAttributes
 // RejectPush reject a push for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#reject
-func (s *DomainsService) RejectPush(accountID string, pushID int) (*DomainPushResponse, error) {
+func (s *DomainsService) RejectPush(accountID string, pushID int) (*domainPushResponse, error) {
 	path := versioned(domainPushPath(accountID, pushID))
-	pushResponse := &DomainPushResponse{}
+	pushResponse := &domainPushResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/identity.go
+++ b/dnsimple/identity.go
@@ -15,8 +15,8 @@ type WhoamiData struct {
 	Account *Account `json:"account,omitempty"`
 }
 
-// WhoamiResponse represents a response from an API method that returns a Whoami struct.
-type WhoamiResponse struct {
+// whoamiResponse represents a response from an API method that returns a Whoami struct.
+type whoamiResponse struct {
 	Response
 	Data *WhoamiData `json:"data"`
 }
@@ -24,9 +24,9 @@ type WhoamiResponse struct {
 // Whoami gets the current authenticate context.
 //
 // See https://developer.dnsimple.com/v2/whoami
-func (s *IdentityService) Whoami() (*WhoamiResponse, error) {
+func (s *IdentityService) Whoami() (*whoamiResponse, error) {
 	path := versioned("/whoami")
-	whoamiResponse := &WhoamiResponse{}
+	whoamiResponse := &whoamiResponse{}
 
 	resp, err := s.client.get(path, whoamiResponse)
 	if err != nil {

--- a/dnsimple/live_test.go
+++ b/dnsimple/live_test.go
@@ -99,8 +99,8 @@ func TestLive_Webhooks(t *testing.T) {
 
 	var err error
 	var webhook *Webhook
-	var webhookResponse *WebhookResponse
-	var webhooksResponse *WebhooksResponse
+	var webhookResponse *webhookResponse
+	var webhooksResponse *webhooksResponse
 
 	whoami, err := Whoami(dnsimpleClient)
 	if err != nil {

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -19,8 +19,8 @@ type DomainCheck struct {
 	Premium   bool   `json:"premium"`
 }
 
-// DomainCheckResponse represents a response from a domain check request.
-type DomainCheckResponse struct {
+// domainCheckResponse represents a response from a domain check request.
+type domainCheckResponse struct {
 	Response
 	Data *DomainCheck `json:"data"`
 }
@@ -28,9 +28,9 @@ type DomainCheckResponse struct {
 // CheckDomain checks a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#check
-func (s *RegistrarService) CheckDomain(accountID, domainName string) (*DomainCheckResponse, error) {
+func (s *RegistrarService) CheckDomain(accountID, domainName string) (*domainCheckResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/check", accountID, domainName))
-	checkResponse := &DomainCheckResponse{}
+	checkResponse := &domainCheckResponse{}
 
 	resp, err := s.client.get(path, checkResponse)
 	if err != nil {
@@ -50,8 +50,8 @@ type DomainPremiumPrice struct {
 	Action string `json:"action"`
 }
 
-// DomainPremiumPriceResponse represents a response from a domain premium price request.
-type DomainPremiumPriceResponse struct {
+// domainPremiumPriceResponse represents a response from a domain premium price request.
+type domainPremiumPriceResponse struct {
 	Response
 	Data *DomainPremiumPrice `json:"data"`
 }
@@ -70,10 +70,10 @@ type DomainPremiumPriceOptions struct {
 // - renewal
 //
 // See https://developer.dnsimple.com/v2/registrar/#premium-price
-func (s *RegistrarService) GetDomainPremiumPrice(accountID, domainName string, options *DomainPremiumPriceOptions) (*DomainPremiumPriceResponse, error) {
+func (s *RegistrarService) GetDomainPremiumPrice(accountID, domainName string, options *DomainPremiumPriceOptions) (*domainPremiumPriceResponse, error) {
 	var err error
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/premium_price", accountID, domainName))
-	priceResponse := &DomainPremiumPriceResponse{}
+	priceResponse := &domainPremiumPriceResponse{}
 
 	if options != nil {
 		path, err = addURLQueryOptions(path, options)
@@ -91,19 +91,6 @@ func (s *RegistrarService) GetDomainPremiumPrice(accountID, domainName string, o
 	return priceResponse, nil
 }
 
-// DomainRegisterRequest represents the attributes you can pass to a register API request.
-// Some attributes are mandatory.
-type DomainRegisterRequest struct {
-	// The ID of the Contact to use as registrant for the domain
-	RegistrantID int `json:"registrant_id"`
-	// Set to true to enable the whois privacy service. An extra cost may apply.
-	// Default to false.
-	EnableWhoisPrivacy bool `json:"whois_privacy,omitempty"`
-	// Set to true to enable the auto-renewal of the domain.
-	// Default to true.
-	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
-}
-
 // DomainRegistration represents the result of a domain renewal call.
 type DomainRegistration struct {
 	ID           int    `json:"id"`
@@ -118,18 +105,31 @@ type DomainRegistration struct {
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
-// DomainRegistrationResponse represents a response from an API method that results in a domain registration.
-type DomainRegistrationResponse struct {
+// domainRegistrationResponse represents a response from an API method that results in a domain registration.
+type domainRegistrationResponse struct {
 	Response
 	Data *DomainRegistration `json:"data"`
+}
+
+// DomainRegisterRequest represents the attributes you can pass to a register API request.
+// Some attributes are mandatory.
+type DomainRegisterRequest struct {
+	// The ID of the Contact to use as registrant for the domain
+	RegistrantID int `json:"registrant_id"`
+	// Set to true to enable the whois privacy service. An extra cost may apply.
+	// Default to false.
+	EnableWhoisPrivacy bool `json:"whois_privacy,omitempty"`
+	// Set to true to enable the auto-renewal of the domain.
+	// Default to true.
+	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 }
 
 // RegisterDomain registers a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#register
-func (s *RegistrarService) RegisterDomain(accountID string, domainName string, request *DomainRegisterRequest) (*DomainRegistrationResponse, error) {
+func (s *RegistrarService) RegisterDomain(accountID string, domainName string, request *DomainRegisterRequest) (*domainRegistrationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/registration", accountID, domainName))
-	registrationResponse := &DomainRegistrationResponse{}
+	registrationResponse := &domainRegistrationResponse{}
 
 	// TODO: validate mandatory attributes RegistrantID
 
@@ -140,6 +140,25 @@ func (s *RegistrarService) RegisterDomain(accountID string, domainName string, r
 
 	registrationResponse.HttpResponse = resp
 	return registrationResponse, nil
+}
+
+// DomainTransfer represents the result of a domain renewal call.
+type DomainTransfer struct {
+	ID           int    `json:"id"`
+	DomainID     int    `json:"domain_id"`
+	RegistrantID int    `json:"registrant_id"`
+	State        string `json:"state"`
+	AutoRenew    bool   `json:"auto_renew"`
+	WhoisPrivacy bool   `json:"whois_privacy"`
+	PremiumPrice string `json:"premium_price"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+// domainTransferResponse represents a response from an API method that results in a domain transfer.
+type domainTransferResponse struct {
+	Response
+	Data *DomainTransfer `json:"data"`
 }
 
 // DomainTransferRequest represents the attributes you can pass to a transfer API request.
@@ -158,31 +177,12 @@ type DomainTransferRequest struct {
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 }
 
-// DomainTransfer represents the result of a domain renewal call.
-type DomainTransfer struct {
-	ID           int    `json:"id"`
-	DomainID     int    `json:"domain_id"`
-	RegistrantID int    `json:"registrant_id"`
-	State        string `json:"state"`
-	AutoRenew    bool   `json:"auto_renew"`
-	WhoisPrivacy bool   `json:"whois_privacy"`
-	PremiumPrice string `json:"premium_price"`
-	CreatedAt    string `json:"created_at,omitempty"`
-	UpdatedAt    string `json:"updated_at,omitempty"`
-}
-
-// DomainTransferResponse represents a response from an API method that results in a domain transfer.
-type DomainTransferResponse struct {
-	Response
-	Data *DomainTransfer `json:"data"`
-}
-
 // TransferDomain transfers a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#transfer
-func (s *RegistrarService) TransferDomain(accountID string, domainName string, request *DomainTransferRequest) (*DomainTransferResponse, error) {
+func (s *RegistrarService) TransferDomain(accountID string, domainName string, request *DomainTransferRequest) (*domainTransferResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfer", accountID, domainName))
-	transferResponse := &DomainTransferResponse{}
+	transferResponse := &domainTransferResponse{}
 
 	// TODO: validate mandatory attributes RegistrantID
 
@@ -195,8 +195,8 @@ func (s *RegistrarService) TransferDomain(accountID string, domainName string, r
 	return transferResponse, nil
 }
 
-// DomainTransferOutResponse represents a response from an API method that results in a domain transfer out.
-type DomainTransferOutResponse struct {
+// domainTransferOutResponse represents a response from an API method that results in a domain transfer out.
+type domainTransferOutResponse struct {
 	Response
 	Data *Domain `json:"data"`
 }
@@ -204,9 +204,9 @@ type DomainTransferOutResponse struct {
 // Transfer out a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#transfer-out
-func (s *RegistrarService) TransferDomainOut(accountID string, domainName string) (*DomainTransferOutResponse, error) {
+func (s *RegistrarService) TransferDomainOut(accountID string, domainName string) (*domainTransferOutResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfer_out", accountID, domainName))
-	transferResponse := &DomainTransferOutResponse{}
+	transferResponse := &domainTransferOutResponse{}
 
 	resp, err := s.client.post(path, nil, nil)
 	if err != nil {
@@ -215,13 +215,6 @@ func (s *RegistrarService) TransferDomainOut(accountID string, domainName string
 
 	transferResponse.HttpResponse = resp
 	return transferResponse, nil
-}
-
-// DomainRenewRequest represents the attributes you can pass to a renew API request.
-// Some attributes are mandatory.
-type DomainRenewRequest struct {
-	// The number of years
-	Period int `json:"period"`
 }
 
 // DomainRenewal represents the result of a domain renewal call.
@@ -235,18 +228,25 @@ type DomainRenewal struct {
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
-// DomainRenewalResponse represents a response from an API method that returns a domain renewal.
-type DomainRenewalResponse struct {
+// domainRenewalResponse represents a response from an API method that returns a domain renewal.
+type domainRenewalResponse struct {
 	Response
 	Data *DomainRenewal `json:"data"`
+}
+
+// DomainRenewRequest represents the attributes you can pass to a renew API request.
+// Some attributes are mandatory.
+type DomainRenewRequest struct {
+	// The number of years
+	Period int `json:"period"`
 }
 
 // RenewDomain renews a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#register
-func (s *RegistrarService) RenewDomain(accountID string, domainName string, request *DomainRenewRequest) (*DomainRenewalResponse, error) {
+func (s *RegistrarService) RenewDomain(accountID string, domainName string, request *DomainRenewRequest) (*domainRenewalResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/renewal", accountID, domainName))
-	renewalResponse := &DomainRenewalResponse{}
+	renewalResponse := &domainRenewalResponse{}
 
 	resp, err := s.client.post(path, request, renewalResponse)
 	if err != nil {

--- a/dnsimple/registrar_auto_renewal.go
+++ b/dnsimple/registrar_auto_renewal.go
@@ -7,9 +7,9 @@ import (
 // EnableDomainAutoRenewal enables auto-renewal for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
-func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName string) (*DomainResponse, error) {
+func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName string) (*domainResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
-	domainResponse := &DomainResponse{}
+	domainResponse := &domainResponse{}
 
 	resp, err := s.client.put(path, nil, nil)
 	if err != nil {
@@ -23,9 +23,9 @@ func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName 
 // DisableDomainAutoRenewal disables auto-renewal for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
-func (s *RegistrarService) DisableDomainAutoRenewal(accountID string, domainName string) (*DomainResponse, error) {
+func (s *RegistrarService) DisableDomainAutoRenewal(accountID string, domainName string) (*domainResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
-	domainResponse := &DomainResponse{}
+	domainResponse := &domainResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/registrar_delegation.go
+++ b/dnsimple/registrar_delegation.go
@@ -7,14 +7,14 @@ import (
 // Delegation represents a list of name servers that correspond to a domain delegation.
 type Delegation []string
 
-// DelegationResponse represents a response from an API method that returns a delegation struct.
-type DelegationResponse struct {
+// delegationResponse represents a response from an API method that returns a delegation struct.
+type delegationResponse struct {
 	Response
 	Data *Delegation `json:"data"`
 }
 
-// VanityDelegationResponse represents a response for vanity name server enable and disable operations.
-type VanityDelegationResponse struct {
+// vanityDelegationResponse represents a response for vanity name server enable and disable operations.
+type vanityDelegationResponse struct {
 	Response
 	Data []VanityNameServer `json:"data"`
 }
@@ -22,9 +22,9 @@ type VanityDelegationResponse struct {
 // GetDomainDelegation gets the current delegated name servers for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#get
-func (s *RegistrarService) GetDomainDelegation(accountID string, domainName string) (*DelegationResponse, error) {
+func (s *RegistrarService) GetDomainDelegation(accountID string, domainName string) (*delegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
-	delegationResponse := &DelegationResponse{}
+	delegationResponse := &delegationResponse{}
 
 	resp, err := s.client.get(path, delegationResponse)
 	if err != nil {
@@ -38,9 +38,9 @@ func (s *RegistrarService) GetDomainDelegation(accountID string, domainName stri
 // ChangeDomainDelegation updates the delegated name severs for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#get
-func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName string, newDelegation *Delegation) (*DelegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName string, newDelegation *Delegation) (*delegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
-	delegationResponse := &DelegationResponse{}
+	delegationResponse := &delegationResponse{}
 
 	resp, err := s.client.put(path, newDelegation, delegationResponse)
 	if err != nil {
@@ -54,9 +54,9 @@ func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName s
 // ChangeDomainDelegationToVanity enables vanity name servers for the given domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#delegateToVanity
-func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, domainName string, newDelegation *Delegation) (*VanityDelegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, domainName string, newDelegation *Delegation) (*vanityDelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
-	delegationResponse := &VanityDelegationResponse{}
+	delegationResponse := &vanityDelegationResponse{}
 
 	resp, err := s.client.put(path, newDelegation, delegationResponse)
 	if err != nil {
@@ -70,9 +70,9 @@ func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, doma
 // ChangeDomainDelegationFromVanity disables vanity name servers for the given domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#dedelegateFromVanity
-func (s *RegistrarService) ChangeDomainDelegationFromVanity(accountID string, domainName string) (*VanityDelegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegationFromVanity(accountID string, domainName string) (*vanityDelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
-	delegationResponse := &VanityDelegationResponse{}
+	delegationResponse := &vanityDelegationResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -14,8 +14,8 @@ type WhoisPrivacy struct {
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-// WhoisPrivacyResponse represents a response from an API method that returns a WhoisPrivacy struct.
-type WhoisPrivacyResponse struct {
+// whoisPrivacyResponse represents a response from an API method that returns a WhoisPrivacy struct.
+type whoisPrivacyResponse struct {
 	Response
 	Data *WhoisPrivacy `json:"data"`
 }
@@ -23,9 +23,9 @@ type WhoisPrivacyResponse struct {
 // GetWhoisPrivacy gets the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#get
-func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
+func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
-	privacyResponse := &WhoisPrivacyResponse{}
+	privacyResponse := &whoisPrivacyResponse{}
 
 	resp, err := s.client.get(path, privacyResponse)
 	if err != nil {
@@ -39,9 +39,9 @@ func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) 
 // EnableWhoisPrivacy enables the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
-func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
+func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
-	privacyResponse := &WhoisPrivacyResponse{}
+	privacyResponse := &whoisPrivacyResponse{}
 
 	resp, err := s.client.put(path, nil, privacyResponse)
 	if err != nil {
@@ -55,9 +55,9 @@ func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName strin
 // DisablePrivacy disables the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
-func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
+func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
-	privacyResponse := &WhoisPrivacyResponse{}
+	privacyResponse := &whoisPrivacyResponse{}
 
 	resp, err := s.client.delete(path, nil, privacyResponse)
 	if err != nil {

--- a/dnsimple/services.go
+++ b/dnsimple/services.go
@@ -12,16 +12,6 @@ type ServicesService struct {
 	client *Client
 }
 
-// ServiceSetting represents a single group of settings for a DNSimple Service.
-type ServiceSetting struct {
-	Name        string `json:"name,omitempty"`
-	Label       string `json:"label,omitempty"`
-	Append      string `json:"append,omitempty"`
-	Description string `json:"description,omitempty"`
-	Example     string `json:"example,omitempty"`
-	Password    bool   `json:"password,omitempty"`
-}
-
 // Service represents a Service in DNSimple.
 type Service struct {
 	ID               int              `json:"id,omitempty"`
@@ -36,6 +26,16 @@ type Service struct {
 	Settings         []ServiceSetting `json:"settings,omitempty"`
 }
 
+// ServiceSetting represents a single group of settings for a DNSimple Service.
+type ServiceSetting struct {
+	Name        string `json:"name,omitempty"`
+	Label       string `json:"label,omitempty"`
+	Append      string `json:"append,omitempty"`
+	Description string `json:"description,omitempty"`
+	Example     string `json:"example,omitempty"`
+	Password    bool   `json:"password,omitempty"`
+}
+
 func servicePath(serviceID string) (path string) {
 	path = "/services"
 	if serviceID != "" {
@@ -44,14 +44,14 @@ func servicePath(serviceID string) (path string) {
 	return
 }
 
-// ServiceResponse represents a response from an API method that returns a Service struct.
-type ServiceResponse struct {
+// serviceResponse represents a response from an API method that returns a Service struct.
+type serviceResponse struct {
 	Response
 	Data *Service `json:"data"`
 }
 
-// ServicesResponse represents a response from an API method that returns a collection of Service struct.
-type ServicesResponse struct {
+// servicesResponse represents a response from an API method that returns a collection of Service struct.
+type servicesResponse struct {
 	Response
 	Data []Service `json:"data"`
 }
@@ -59,9 +59,9 @@ type ServicesResponse struct {
 // ListServices lists the one-click services available in DNSimple.
 //
 // See https://developer.dnsimple.com/v2/services/#list
-func (s *ServicesService) ListServices(options *ListOptions) (*ServicesResponse, error) {
+func (s *ServicesService) ListServices(options *ListOptions) (*servicesResponse, error) {
 	path := versioned(servicePath(""))
-	servicesResponse := &ServicesResponse{}
+	servicesResponse := &servicesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -80,9 +80,9 @@ func (s *ServicesService) ListServices(options *ListOptions) (*ServicesResponse,
 // GetService fetches a one-click service.
 //
 // See https://developer.dnsimple.com/v2/services/#get
-func (s *ServicesService) GetService(serviceIdentifier string) (*ServiceResponse, error) {
+func (s *ServicesService) GetService(serviceIdentifier string) (*serviceResponse, error) {
 	path := versioned(servicePath(serviceIdentifier))
-	serviceResponse := &ServiceResponse{}
+	serviceResponse := &serviceResponse{}
 
 	resp, err := s.client.get(path, serviceResponse)
 	if err != nil {

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -19,9 +19,9 @@ type DomainServiceSettings struct {
 // AppliedServices lists the applied one-click services for a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#applied
-func (s *ServicesService) AppliedServices(accountID string, domainID string, options *ListOptions) (*ServicesResponse, error) {
+func (s *ServicesService) AppliedServices(accountID string, domainID string, options *ListOptions) (*servicesResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainID, ""))
-	servicesResponse := &ServicesResponse{}
+	servicesResponse := &servicesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -40,9 +40,9 @@ func (s *ServicesService) AppliedServices(accountID string, domainID string, opt
 // ApplyService applies a one-click services to a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#apply
-func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainID string, settings DomainServiceSettings) (*ServiceResponse, error) {
+func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainID string, settings DomainServiceSettings) (*serviceResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainID, serviceIdentifier))
-	serviceResponse := &ServiceResponse{}
+	serviceResponse := &serviceResponse{}
 
 	resp, err := s.client.post(path, settings, nil)
 	if err != nil {
@@ -56,9 +56,9 @@ func (s *ServicesService) ApplyService(accountID string, serviceIdentifier strin
 // UnapplyService unapplies a one-click services from a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#unapply
-func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainID string) (*ServiceResponse, error) {
+func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainID string) (*serviceResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainID, serviceIdentifier))
-	serviceResponse := &ServiceResponse{}
+	serviceResponse := &serviceResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/templates.go
+++ b/dnsimple/templates.go
@@ -31,14 +31,14 @@ func templatePath(accountID string, templateIdentifier string) (path string) {
 	return
 }
 
-// TemplateResponse represents a response from an API method that returns a Template struct.
-type TemplateResponse struct {
+// templateResponse represents a response from an API method that returns a Template struct.
+type templateResponse struct {
 	Response
 	Data *Template `json:"data"`
 }
 
-// TemplatesResponse represents a response from an API method that returns a collection of Template struct.
-type TemplatesResponse struct {
+// templatesResponse represents a response from an API method that returns a collection of Template struct.
+type templatesResponse struct {
 	Response
 	Data []Template `json:"data"`
 }
@@ -46,9 +46,9 @@ type TemplatesResponse struct {
 // ListTemplates list the templates for an account.
 //
 // See https://developer.dnsimple.com/v2/templates/#list
-func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions) (*TemplatesResponse, error) {
+func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions) (*templatesResponse, error) {
 	path := versioned(templatePath(accountID, ""))
-	templatesResponse := &TemplatesResponse{}
+	templatesResponse := &templatesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -67,9 +67,9 @@ func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions)
 // CreateTemplate creates a new template.
 //
 // See https://developer.dnsimple.com/v2/templates/#create
-func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes Template) (*TemplateResponse, error) {
+func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes Template) (*templateResponse, error) {
 	path := versioned(templatePath(accountID, ""))
-	templateResponse := &TemplateResponse{}
+	templateResponse := &templateResponse{}
 
 	resp, err := s.client.post(path, templateAttributes, templateResponse)
 	if err != nil {
@@ -83,9 +83,9 @@ func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes T
 // GetTemplate fetches a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#get
-func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier string) (*TemplateResponse, error) {
+func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier string) (*templateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
-	templateResponse := &TemplateResponse{}
+	templateResponse := &templateResponse{}
 
 	resp, err := s.client.get(path, templateResponse)
 	if err != nil {
@@ -99,9 +99,9 @@ func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier stri
 // UpdateTemplate updates a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#update
-func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier string, templateAttributes Template) (*TemplateResponse, error) {
+func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier string, templateAttributes Template) (*templateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
-	templateResponse := &TemplateResponse{}
+	templateResponse := &templateResponse{}
 
 	resp, err := s.client.patch(path, templateAttributes, templateResponse)
 	if err != nil {
@@ -115,9 +115,9 @@ func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier s
 // DeleteTemplate deletes a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#delete
-func (s *TemplatesService) DeleteTemplate(accountID string, templateIdentifier string) (*TemplateResponse, error) {
+func (s *TemplatesService) DeleteTemplate(accountID string, templateIdentifier string) (*templateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
-	templateResponse := &TemplateResponse{}
+	templateResponse := &templateResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/templates_domains.go
+++ b/dnsimple/templates_domains.go
@@ -7,9 +7,9 @@ import (
 // ApplyTemplate applies a template to the given domain.
 //
 // See https://developer.dnsimple.com/v2/templates/domains/#apply
-func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier string, domainID string) (*TemplateResponse, error) {
+func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier string, domainID string) (*templateResponse, error) {
 	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath(accountID, domainID), templateIdentifier))
-	templateResponse := &TemplateResponse{}
+	templateResponse := &templateResponse{}
 
 	resp, err := s.client.post(path, nil, nil)
 	if err != nil {

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -17,18 +17,6 @@ type TemplateRecord struct {
 	UpdatedAt  string `json:"updated_at,omitempty"`
 }
 
-// TemplateRecordResponse represents a response from an API method that returns a TemplateRecord struct.
-type TemplateRecordResponse struct {
-	Response
-	Data *TemplateRecord `json:"data"`
-}
-
-// TemplateRecordsResponse represents a response from an API method that returns a collection of TemplateRecord struct.
-type TemplateRecordsResponse struct {
-	Response
-	Data []TemplateRecord `json:"data"`
-}
-
 func templateRecordPath(accountID string, templateIdentifier string, templateRecordID string) string {
 	if templateRecordID != "" {
 		return fmt.Sprintf("%v/records/%v", templatePath(accountID, templateIdentifier), templateRecordID)
@@ -37,12 +25,24 @@ func templateRecordPath(accountID string, templateIdentifier string, templateRec
 	return templatePath(accountID, templateIdentifier) + "/records"
 }
 
+// templateRecordResponse represents a response from an API method that returns a TemplateRecord struct.
+type templateRecordResponse struct {
+	Response
+	Data *TemplateRecord `json:"data"`
+}
+
+// templateRecordsResponse represents a response from an API method that returns a collection of TemplateRecord struct.
+type templateRecordsResponse struct {
+	Response
+	Data []TemplateRecord `json:"data"`
+}
+
 // ListTemplateRecords list the templates for an account.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#list
-func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentifier string, options *ListOptions) (*TemplateRecordsResponse, error) {
+func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentifier string, options *ListOptions) (*templateRecordsResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, ""))
-	templateRecordsResponse := &TemplateRecordsResponse{}
+	templateRecordsResponse := &templateRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -61,9 +61,9 @@ func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentif
 // CreateTemplateRecord creates a new template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#create
-func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*TemplateRecordResponse, error) {
+func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, ""))
-	templateRecordResponse := &TemplateRecordResponse{}
+	templateRecordResponse := &templateRecordResponse{}
 
 	resp, err := s.client.post(path, templateRecordAttributes, templateRecordResponse)
 	if err != nil {
@@ -77,9 +77,9 @@ func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdenti
 // GetTemplateRecord fetches a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#get
-func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*TemplateRecordResponse, error) {
+func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
-	templateRecordResponse := &TemplateRecordResponse{}
+	templateRecordResponse := &templateRecordResponse{}
 
 	resp, err := s.client.get(path, templateRecordResponse)
 	if err != nil {
@@ -93,9 +93,9 @@ func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifie
 // DeleteTemplateRecord deletes a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#delete
-func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*TemplateRecordResponse, error) {
+func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
-	templateRecordResponse := &TemplateRecordResponse{}
+	templateRecordResponse := &templateRecordResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -44,21 +44,21 @@ type TldExtendedAttributeOption struct {
 	Description string `json:"description"`
 }
 
-// TldResponse represents a response from an API method that returns a Tld struct.
-type TldResponse struct {
+// tldResponse represents a response from an API method that returns a Tld struct.
+type tldResponse struct {
 	Response
 	Data *Tld `json:"data"`
 }
 
-// TldsResponse represents a response from an API method that returns a collection of Tld struct.
-type TldsResponse struct {
+// tldsResponse represents a response from an API method that returns a collection of Tld struct.
+type tldsResponse struct {
 	Response
 	Data []Tld `json:"data"`
 }
 
-// TldExtendedAttributesResponse represents a response from an API method that returns
+// tldExtendedAttributesResponse represents a response from an API method that returns
 // a collection of Tld extended attributes.
-type TldExtendedAttributesResponse struct {
+type tldExtendedAttributesResponse struct {
 	Response
 	Data []TldExtendedAttribute `json:"data"`
 }
@@ -66,9 +66,9 @@ type TldExtendedAttributesResponse struct {
 // ListTlds lists the supported TLDs.
 //
 // See https://developer.dnsimple.com/v2/tlds/#list
-func (s *TldsService) ListTlds(options *ListOptions) (*TldsResponse, error) {
+func (s *TldsService) ListTlds(options *ListOptions) (*tldsResponse, error) {
 	path := versioned("/tlds")
-	tldsResponse := &TldsResponse{}
+	tldsResponse := &tldsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -87,9 +87,9 @@ func (s *TldsService) ListTlds(options *ListOptions) (*TldsResponse, error) {
 // GetTld fetches a TLD.
 //
 // See https://developer.dnsimple.com/v2/tlds/#get
-func (s *TldsService) GetTld(tld string) (*TldResponse, error) {
+func (s *TldsService) GetTld(tld string) (*tldResponse, error) {
 	path := versioned(fmt.Sprintf("/tlds/%s", tld))
-	tldResponse := &TldResponse{}
+	tldResponse := &tldResponse{}
 
 	resp, err := s.client.get(path, tldResponse)
 	if err != nil {
@@ -103,9 +103,9 @@ func (s *TldsService) GetTld(tld string) (*TldResponse, error) {
 // GetTld fetches the extended attributes of a TLD.
 //
 // See https://developer.dnsimple.com/v2/tlds/#get
-func (s *TldsService) GetTldExtendedAttributes(tld string) (*TldExtendedAttributesResponse, error) {
+func (s *TldsService) GetTldExtendedAttributes(tld string) (*tldExtendedAttributesResponse, error) {
 	path := versioned(fmt.Sprintf("/tlds/%s/extended_attributes", tld))
-	tldResponse := &TldExtendedAttributesResponse{}
+	tldResponse := &tldExtendedAttributesResponse{}
 
 	resp, err := s.client.get(path, tldResponse)
 	if err != nil {

--- a/dnsimple/vanity_name_server.go
+++ b/dnsimple/vanity_name_server.go
@@ -22,22 +22,22 @@ type VanityNameServer struct {
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-// VanityNameServerResponse represents a response for vanity name server enable and disable operations.
-type VanityNameServerResponse struct {
-	Response
-	Data []VanityNameServer `json:"data"`
-}
-
 func vanityNameServerPath(accountID string, domainID string) string {
 	return fmt.Sprintf("/%v/vanity/%v", accountID, domainID)
+}
+
+// vanityNameServerResponse represents a response for vanity name server enable and disable operations.
+type vanityNameServerResponse struct {
+	Response
+	Data []VanityNameServer `json:"data"`
 }
 
 // EnableVanityNameServers Vanity Name Servers for the given domain
 //
 // See https://developer.dnsimple.com/v2/vanity/#enable
-func (s *VanityNameServersService) EnableVanityNameServers(accountID string, domainID string) (*VanityNameServerResponse, error) {
+func (s *VanityNameServersService) EnableVanityNameServers(accountID string, domainID string) (*vanityNameServerResponse, error) {
 	path := versioned(vanityNameServerPath(accountID, domainID))
-	vanityNameServerResponse := &VanityNameServerResponse{}
+	vanityNameServerResponse := &vanityNameServerResponse{}
 
 	resp, err := s.client.put(path, nil, vanityNameServerResponse)
 	if err != nil {
@@ -51,9 +51,9 @@ func (s *VanityNameServersService) EnableVanityNameServers(accountID string, dom
 // DisableVanityNameServers Vanity Name Servers for the given domain
 //
 // See https://developer.dnsimple.com/v2/vanity/#disable
-func (s *VanityNameServersService) DisableVanityNameServers(accountID string, domainID string) (*VanityNameServerResponse, error) {
+func (s *VanityNameServersService) DisableVanityNameServers(accountID string, domainID string) (*vanityNameServerResponse, error) {
 	path := versioned(vanityNameServerPath(accountID, domainID))
-	vanityNameServerResponse := &VanityNameServerResponse{}
+	vanityNameServerResponse := &vanityNameServerResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/webhooks.go
+++ b/dnsimple/webhooks.go
@@ -18,19 +18,6 @@ type Webhook struct {
 	URL string `json:"url,omitempty"`
 }
 
-// WebhookResponse represents a response from an API method that returns a Webhook struct.
-type WebhookResponse struct {
-	Response
-	Data *Webhook `json:"data"`
-}
-
-// WebhookResponse represents a response from an API method that returns a collection of Webhook struct.
-type WebhooksResponse struct {
-	Response
-	Data []Webhook `json:"data"`
-}
-
-// webhookPath generates the resource path for given webhook.
 func webhookPath(accountID string, webhookID int) (path string) {
 	path = fmt.Sprintf("/%v/webhooks", accountID)
 	if webhookID != 0 {
@@ -39,12 +26,24 @@ func webhookPath(accountID string, webhookID int) (path string) {
 	return
 }
 
+// webhookResponse represents a response from an API method that returns a Webhook struct.
+type webhookResponse struct {
+	Response
+	Data *Webhook `json:"data"`
+}
+
+// webhookResponse represents a response from an API method that returns a collection of Webhook struct.
+type webhooksResponse struct {
+	Response
+	Data []Webhook `json:"data"`
+}
+
 // ListWebhooks lists the webhooks for an account.
 //
 // See https://developer.dnsimple.com/v2/webhooks#list
-func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*WebhooksResponse, error) {
+func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*webhooksResponse, error) {
 	path := versioned(webhookPath(accountID, 0))
-	webhooksResponse := &WebhooksResponse{}
+	webhooksResponse := &webhooksResponse{}
 
 	resp, err := s.client.get(path, webhooksResponse)
 	if err != nil {
@@ -58,9 +57,9 @@ func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*Webho
 // CreateWebhook creates a new webhook.
 //
 // See https://developer.dnsimple.com/v2/webhooks#create
-func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webhook) (*WebhookResponse, error) {
+func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webhook) (*webhookResponse, error) {
 	path := versioned(webhookPath(accountID, 0))
-	webhookResponse := &WebhookResponse{}
+	webhookResponse := &webhookResponse{}
 
 	resp, err := s.client.post(path, webhookAttributes, webhookResponse)
 	if err != nil {
@@ -74,9 +73,9 @@ func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webh
 // GetWebhook fetches a webhook.
 //
 // See https://developer.dnsimple.com/v2/webhooks#get
-func (s *WebhooksService) GetWebhook(accountID string, webhookID int) (*WebhookResponse, error) {
+func (s *WebhooksService) GetWebhook(accountID string, webhookID int) (*webhookResponse, error) {
 	path := versioned(webhookPath(accountID, webhookID))
-	webhookResponse := &WebhookResponse{}
+	webhookResponse := &webhookResponse{}
 
 	resp, err := s.client.get(path, webhookResponse)
 	if err != nil {
@@ -90,9 +89,9 @@ func (s *WebhooksService) GetWebhook(accountID string, webhookID int) (*WebhookR
 // DeleteWebhook PERMANENTLY deletes a webhook from the account.
 //
 // See https://developer.dnsimple.com/v2/webhooks#delete
-func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int) (*WebhookResponse, error) {
+func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int) (*webhookResponse, error) {
 	path := versioned(webhookPath(accountID, webhookID))
-	webhookResponse := &WebhookResponse{}
+	webhookResponse := &webhookResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -27,6 +27,24 @@ type ZoneFile struct {
 	Zone string `json:"zone,omitempty"`
 }
 
+// zoneResponse represents a response from an API method that returns a Zone struct.
+type zoneResponse struct {
+	Response
+	Data *Zone `json:"data"`
+}
+
+// zonesResponse represents a response from an API method that returns a collection of Zone struct.
+type zonesResponse struct {
+	Response
+	Data []Zone `json:"data"`
+}
+
+// zoneFileResponse represents a response from an API method that returns a ZoneFile struct.
+type zoneFileResponse struct {
+	Response
+	Data *ZoneFile `json:"data"`
+}
+
 // ZoneListOptions specifies the optional parameters you can provide
 // to customize the ZonesService.ListZones method.
 type ZoneListOptions struct {
@@ -36,30 +54,12 @@ type ZoneListOptions struct {
 	ListOptions
 }
 
-// ZoneResponse represents a response from an API method that returns a Zone struct.
-type ZoneResponse struct {
-	Response
-	Data *Zone `json:"data"`
-}
-
-// ZonesResponse represents a response from an API method that returns a collection of Zone struct.
-type ZonesResponse struct {
-	Response
-	Data []Zone `json:"data"`
-}
-
-// ZoneFileResponse represents a response from an API method that returns a ZoneFile struct.
-type ZoneFileResponse struct {
-	Response
-	Data *ZoneFile `json:"data"`
-}
-
 // ListZones the zones for an account.
 //
 // See https://developer.dnsimple.com/v2/zones/#list
-func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*ZonesResponse, error) {
+func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*zonesResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones", accountID))
-	zonesResponse := &ZonesResponse{}
+	zonesResponse := &zonesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -78,9 +78,9 @@ func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*Z
 // GetZone fetches a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#get
-func (s *ZonesService) GetZone(accountID string, zoneName string) (*ZoneResponse, error) {
+func (s *ZonesService) GetZone(accountID string, zoneName string) (*zoneResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v", accountID, zoneName))
-	zoneResponse := &ZoneResponse{}
+	zoneResponse := &zoneResponse{}
 
 	resp, err := s.client.get(path, zoneResponse)
 	if err != nil {
@@ -94,9 +94,9 @@ func (s *ZonesService) GetZone(accountID string, zoneName string) (*ZoneResponse
 // GetZoneFile fetches a zone file.
 //
 // See https://developer.dnsimple.com/v2/zones/#get-file
-func (s *ZonesService) GetZoneFile(accountID string, zoneName string) (*ZoneFileResponse, error) {
+func (s *ZonesService) GetZoneFile(accountID string, zoneName string) (*zoneFileResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v/file", accountID, zoneName))
-	zoneFileResponse := &ZoneFileResponse{}
+	zoneFileResponse := &zoneFileResponse{}
 
 	resp, err := s.client.get(path, zoneFileResponse)
 	if err != nil {

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -28,6 +28,18 @@ func zoneRecordPath(accountID string, zoneID string, recordID int) (path string)
 	return
 }
 
+// zoneRecordResponse represents a response from an API method that returns a ZoneRecord struct.
+type zoneRecordResponse struct {
+	Response
+	Data *ZoneRecord `json:"data"`
+}
+
+// zoneRecordsResponse represents a response from an API method that returns a collection of ZoneRecord struct.
+type zoneRecordsResponse struct {
+	Response
+	Data []ZoneRecord `json:"data"`
+}
+
 // ZoneRecordListOptions specifies the optional parameters you can provide
 // to customize the ZonesService.ListZoneRecords method.
 type ZoneRecordListOptions struct {
@@ -44,24 +56,12 @@ type ZoneRecordListOptions struct {
 	ListOptions
 }
 
-// ZoneRecordResponse represents a response from an API method that returns a ZoneRecord struct.
-type ZoneRecordResponse struct {
-	Response
-	Data *ZoneRecord `json:"data"`
-}
-
-// ZoneRecordsResponse represents a response from an API method that returns a collection of ZoneRecord struct.
-type ZoneRecordsResponse struct {
-	Response
-	Data []ZoneRecord `json:"data"`
-}
-
 // ListRecords lists the zone records for a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#list
-func (s *ZonesService) ListRecords(accountID string, zoneID string, options *ZoneRecordListOptions) (*ZoneRecordsResponse, error) {
+func (s *ZonesService) ListRecords(accountID string, zoneID string, options *ZoneRecordListOptions) (*zoneRecordsResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneID, 0))
-	recordsResponse := &ZoneRecordsResponse{}
+	recordsResponse := &zoneRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -80,9 +80,9 @@ func (s *ZonesService) ListRecords(accountID string, zoneID string, options *Zon
 // CreateRecord creates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#create
-func (s *ZonesService) CreateRecord(accountID string, zoneID string, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
+func (s *ZonesService) CreateRecord(accountID string, zoneID string, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneID, 0))
-	recordResponse := &ZoneRecordResponse{}
+	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.post(path, recordAttributes, recordResponse)
 	if err != nil {
@@ -96,9 +96,9 @@ func (s *ZonesService) CreateRecord(accountID string, zoneID string, recordAttri
 // GetRecord fetches a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#get
-func (s *ZonesService) GetRecord(accountID string, zoneID string, recordID int) (*ZoneRecordResponse, error) {
+func (s *ZonesService) GetRecord(accountID string, zoneID string, recordID int) (*zoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
-	recordResponse := &ZoneRecordResponse{}
+	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.get(path, recordResponse)
 	if err != nil {
@@ -112,9 +112,9 @@ func (s *ZonesService) GetRecord(accountID string, zoneID string, recordID int) 
 // UpdateRecord updates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#update
-func (s *ZonesService) UpdateRecord(accountID string, zoneID string, recordID int, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
+func (s *ZonesService) UpdateRecord(accountID string, zoneID string, recordID int, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
-	recordResponse := &ZoneRecordResponse{}
+	recordResponse := &zoneRecordResponse{}
 	resp, err := s.client.patch(path, recordAttributes, recordResponse)
 
 	if err != nil {
@@ -128,9 +128,9 @@ func (s *ZonesService) UpdateRecord(accountID string, zoneID string, recordID in
 // DeleteRecord PERMANENTLY deletes a zone record from the zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#delete
-func (s *ZonesService) DeleteRecord(accountID string, zoneID string, recordID int) (*ZoneRecordResponse, error) {
+func (s *ZonesService) DeleteRecord(accountID string, zoneID string, recordID int) (*zoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
-	recordResponse := &ZoneRecordResponse{}
+	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {


### PR DESCRIPTION
Response types are used internally as a container for the response data
and headers. Consumers should not rely on them, but instead interact
with the data and (if necessary) build custom types.

/cc @aeden @jodosha 