### PR TITLE
Update registrar URLs

### DIFF
--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -205,7 +205,7 @@ type domainTransferOutResponse struct {
 //
 // See https://developer.dnsimple.com/v2/registrar/#transfer-out
 func (s *RegistrarService) TransferDomainOut(accountID string, domainName string) (*domainTransferOutResponse, error) {
-	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfer_out", accountID, domainName))
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/authorize_transfer_out", accountID, domainName))
 	transferResponse := &domainTransferOutResponse{}
 
 	resp, err := s.client.post(path, nil, nil)

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -128,7 +128,7 @@ type DomainRegisterRequest struct {
 //
 // See https://developer.dnsimple.com/v2/registrar/#register
 func (s *RegistrarService) RegisterDomain(accountID string, domainName string, request *DomainRegisterRequest) (*domainRegistrationResponse, error) {
-	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/registration", accountID, domainName))
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/registrations", accountID, domainName))
 	registrationResponse := &domainRegistrationResponse{}
 
 	// TODO: validate mandatory attributes RegistrantID

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -181,7 +181,7 @@ type DomainTransferRequest struct {
 //
 // See https://developer.dnsimple.com/v2/registrar/#transfer
 func (s *RegistrarService) TransferDomain(accountID string, domainName string, request *DomainTransferRequest) (*domainTransferResponse, error) {
-	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfer", accountID, domainName))
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfers", accountID, domainName))
 	transferResponse := &domainTransferResponse{}
 
 	// TODO: validate mandatory attributes RegistrantID

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -245,7 +245,7 @@ type DomainRenewRequest struct {
 //
 // See https://developer.dnsimple.com/v2/registrar/#register
 func (s *RegistrarService) RenewDomain(accountID string, domainName string, request *DomainRenewRequest) (*domainRenewalResponse, error) {
-	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/renewal", accountID, domainName))
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/renewals", accountID, domainName))
 	renewalResponse := &domainRenewalResponse{}
 
 	resp, err := s.client.post(path, request, renewalResponse)

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -118,7 +118,7 @@ func TestRegistrarService_TransferDomain(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
-	mux.HandleFunc("/v2/1010/registrar/domains/example.com/transfer", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/1010/registrar/domains/example.com/transfers", func(w http.ResponseWriter, r *http.Request) {
 		httpResponse := httpResponseFixture(t, "/transferDomain/success.http")
 
 		testMethod(t, r, "POST")

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -171,7 +171,7 @@ func TestRegistrarService_RenewDomain(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
-	mux.HandleFunc("/v2/1010/registrar/domains/example.com/renewal", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/1010/registrar/domains/example.com/renewals", func(w http.ResponseWriter, r *http.Request) {
 		httpResponse := httpResponseFixture(t, "/renewDomain/success.http")
 
 		testMethod(t, r, "POST")

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -151,7 +151,7 @@ func TestRegistrarService_TransferDomainOut(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
-	mux.HandleFunc("/v2/1010/registrar/domains/example.com/transfer_out", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/1010/registrar/domains/example.com/authorize_transfer_out", func(w http.ResponseWriter, r *http.Request) {
 		httpResponse := httpResponseFixture(t, "/transferDomainOut/success.http")
 
 		testMethod(t, r, "POST")

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -85,7 +85,7 @@ func TestRegistrarService_RegisterDomain(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
-	mux.HandleFunc("/v2/1010/registrar/domains/example.com/registration", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/1010/registrar/domains/example.com/registrations", func(w http.ResponseWriter, r *http.Request) {
 		httpResponse := httpResponseFixture(t, "/registerDomain/success.http")
 
 		testMethod(t, r, "POST")


### PR DESCRIPTION
The registrar methods were using our old, URLs that we decided to migrate before API v2 GA.
This PR updates the URLs to the public, [documented](https://developer.dnsimple.com/v2/registrar/) ones.