### PR TITLE
Use proper identifier types and names

### DIFF
--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -17,9 +17,9 @@ type Collaborator struct {
 	AcceptedAt string `json:"accepted_at,omitempty"`
 }
 
-func collaboratorPath(accountID, domainIdentifier, collaboratorID string) (path string) {
+func collaboratorPath(accountID, domainIdentifier string, collaboratorID int) (path string) {
 	path = fmt.Sprintf("%v/collaborators", domainPath(accountID, domainIdentifier))
-	if collaboratorID != "" {
+	if collaboratorID != 0 {
 		path += fmt.Sprintf("/%v", collaboratorID)
 	}
 	return
@@ -46,7 +46,7 @@ type collaboratorsResponse struct {
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#list
 func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*collaboratorsResponse, error) {
-	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
+	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
 	collaboratorsResponse := &collaboratorsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -67,7 +67,7 @@ func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, o
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
 func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*collaboratorResponse, error) {
-	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
+	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
 	collaboratorResponse := &collaboratorResponse{}
 
 	resp, err := s.client.post(path, attributes, collaboratorResponse)
@@ -81,8 +81,8 @@ func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier stri
 
 // RemoveCollaborator PERMANENTLY deletes a domain from the account.
 //
-// See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID string) (*collaboratorResponse, error) {
+// See https://developer.dnsimple.com/v2/domains/collaborators#remove
+func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID int) (*collaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
 	collaboratorResponse := &collaboratorResponse{}
 

--- a/dnsimple/domains_collaborators_test.go
+++ b/dnsimple/domains_collaborators_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestCollaboratorPath(t *testing.T) {
-	if want, got := "/1010/domains/example.com/collaborators", collaboratorPath("1010", "example.com", ""); want != got {
+	if want, got := "/1010/domains/example.com/collaborators", collaboratorPath("1010", "example.com", 0); want != got {
 		t.Errorf("collaboratorPath(%v) = %v, want %v", "", got, want)
 	}
 
-	if want, got := "/1010/domains/example.com/collaborators/2", collaboratorPath("1010", "example.com", "2"); want != got {
+	if want, got := "/1010/domains/example.com/collaborators/2", collaboratorPath("1010", "example.com", 2); want != got {
 		t.Errorf("collaboratorPath(%v) = %v, want %v", "2", got, want)
 	}
 }
@@ -177,9 +177,9 @@ func TestDomainsService_RemoveCollaborator(t *testing.T) {
 
 	accountID := "1010"
 	domainID := "example.com"
-	contactID := "100"
+	collaboratorID := 100
 
-	_, err := client.Domains.RemoveCollaborator(accountID, domainID, contactID)
+	_, err := client.Domains.RemoveCollaborator(accountID, domainID, collaboratorID)
 	if err != nil {
 		t.Fatalf("Domains.RemoveCollaborator() returned error: %v", err)
 	}

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -19,8 +19,8 @@ type DomainServiceSettings struct {
 // AppliedServices lists the applied one-click services for a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#applied
-func (s *ServicesService) AppliedServices(accountID string, domainID string, options *ListOptions) (*servicesResponse, error) {
-	path := versioned(domainServicesPath(accountID, domainID, ""))
+func (s *ServicesService) AppliedServices(accountID string, domainIdentifier string, options *ListOptions) (*servicesResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainIdentifier, ""))
 	servicesResponse := &servicesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -40,8 +40,8 @@ func (s *ServicesService) AppliedServices(accountID string, domainID string, opt
 // ApplyService applies a one-click services to a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#apply
-func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainID string, settings DomainServiceSettings) (*serviceResponse, error) {
-	path := versioned(domainServicesPath(accountID, domainID, serviceIdentifier))
+func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainIdentifier string, settings DomainServiceSettings) (*serviceResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
 	serviceResponse := &serviceResponse{}
 
 	resp, err := s.client.post(path, settings, nil)
@@ -56,8 +56,8 @@ func (s *ServicesService) ApplyService(accountID string, serviceIdentifier strin
 // UnapplyService unapplies a one-click services from a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#unapply
-func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainID string) (*serviceResponse, error) {
-	path := versioned(domainServicesPath(accountID, domainID, serviceIdentifier))
+func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainIdentifier string) (*serviceResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
 	serviceResponse := &serviceResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -17,8 +17,8 @@ type TemplateRecord struct {
 	UpdatedAt  string `json:"updated_at,omitempty"`
 }
 
-func templateRecordPath(accountID string, templateIdentifier string, templateRecordID string) string {
-	if templateRecordID != "" {
+func templateRecordPath(accountID string, templateIdentifier string, templateRecordID int) string {
+	if templateRecordID != 0 {
 		return fmt.Sprintf("%v/records/%v", templatePath(accountID, templateIdentifier), templateRecordID)
 	}
 
@@ -41,7 +41,7 @@ type templateRecordsResponse struct {
 //
 // See https://developer.dnsimple.com/v2/templates/records/#list
 func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentifier string, options *ListOptions) (*templateRecordsResponse, error) {
-	path := versioned(templateRecordPath(accountID, templateIdentifier, ""))
+	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
 	templateRecordsResponse := &templateRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -62,7 +62,7 @@ func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentif
 //
 // See https://developer.dnsimple.com/v2/templates/records/#create
 func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*templateRecordResponse, error) {
-	path := versioned(templateRecordPath(accountID, templateIdentifier, ""))
+	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
 	templateRecordResponse := &templateRecordResponse{}
 
 	resp, err := s.client.post(path, templateRecordAttributes, templateRecordResponse)
@@ -77,7 +77,7 @@ func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdenti
 // GetTemplateRecord fetches a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#get
-func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*templateRecordResponse, error) {
+func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID int) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &templateRecordResponse{}
 
@@ -93,7 +93,7 @@ func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifie
 // DeleteTemplateRecord deletes a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#delete
-func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*templateRecordResponse, error) {
+func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID int) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &templateRecordResponse{}
 

--- a/dnsimple/templates_records_test.go
+++ b/dnsimple/templates_records_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestTemplates_templateRecordPath(t *testing.T) {
-	if want, got := "/1010/templates/1/records", templateRecordPath("1010", "1", ""); want != got {
+	if want, got := "/1010/templates/1/records", templateRecordPath("1010", "1", 0); want != got {
 		t.Errorf("templateRecordPath(%v, %v, ) = %v, want %v", "1010", "1", got, want)
 	}
 
-	if want, got := "/1010/templates/1/records/2", templateRecordPath("1010", "1", "2"); want != got {
+	if want, got := "/1010/templates/1/records/2", templateRecordPath("1010", "1", 2); want != got {
 		t.Errorf("templateRecordPath(%v, %v, 2) = %v, want %v", "1010", "1", got, want)
 	}
 }
@@ -121,7 +121,7 @@ func TestTemplatesService_GetTemplateRecord(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	templateRecordResponse, err := client.Templates.GetTemplateRecord("1010", "1", "2")
+	templateRecordResponse, err := client.Templates.GetTemplateRecord("1010", "1", 2)
 	if err != nil {
 		t.Fatalf("Templates.GetTemplateRecord() returned error: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestTemplatesService_DeleteTemplateRecord(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Templates.DeleteTemplateRecord("1010", "1", "2")
+	_, err := client.Templates.DeleteTemplateRecord("1010", "1", 2)
 	if err != nil {
 		t.Fatalf("Templates.DeleteTemplateRecord() returned error: %v", err)
 	}

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -20,8 +20,8 @@ type ZoneRecord struct {
 	UpdatedAt    string   `json:"updated_at,omitempty"`
 }
 
-func zoneRecordPath(accountID string, zoneID string, recordID int) (path string) {
-	path = fmt.Sprintf("/%v/zones/%v/records", accountID, zoneID)
+func zoneRecordPath(accountID string, zoneName string, recordID int) (path string) {
+	path = fmt.Sprintf("/%v/zones/%v/records", accountID, zoneName)
 	if recordID != 0 {
 		path += fmt.Sprintf("/%d", recordID)
 	}
@@ -59,8 +59,8 @@ type ZoneRecordListOptions struct {
 // ListRecords lists the zone records for a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#list
-func (s *ZonesService) ListRecords(accountID string, zoneID string, options *ZoneRecordListOptions) (*zoneRecordsResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, 0))
+func (s *ZonesService) ListRecords(accountID string, zoneName string, options *ZoneRecordListOptions) (*zoneRecordsResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, 0))
 	recordsResponse := &zoneRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -80,8 +80,8 @@ func (s *ZonesService) ListRecords(accountID string, zoneID string, options *Zon
 // CreateRecord creates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#create
-func (s *ZonesService) CreateRecord(accountID string, zoneID string, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, 0))
+func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, 0))
 	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.post(path, recordAttributes, recordResponse)
@@ -96,8 +96,8 @@ func (s *ZonesService) CreateRecord(accountID string, zoneID string, recordAttri
 // GetRecord fetches a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#get
-func (s *ZonesService) GetRecord(accountID string, zoneID string, recordID int) (*zoneRecordResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.get(path, recordResponse)
@@ -112,8 +112,8 @@ func (s *ZonesService) GetRecord(accountID string, zoneID string, recordID int) 
 // UpdateRecord updates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#update
-func (s *ZonesService) UpdateRecord(accountID string, zoneID string, recordID int, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID int, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 	resp, err := s.client.patch(path, recordAttributes, recordResponse)
 
@@ -128,8 +128,8 @@ func (s *ZonesService) UpdateRecord(accountID string, zoneID string, recordID in
 // DeleteRecord PERMANENTLY deletes a zone record from the zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#delete
-func (s *ZonesService) DeleteRecord(accountID string, zoneID string, recordID int) (*zoneRecordResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+func (s *ZonesService) DeleteRecord(accountID string, zoneName string, recordID int) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)


### PR DESCRIPTION
Adopting the following conventions:

- modelID: the model int ID
- modelIdentifier: the model int ID and/or a string short-identifier
- zoneName vs zoneID: be explicit when possible. Do not use zoneIdentifier or zoneID when you require the zoneName (closes GH-23)