### PR TITLE
Convert int identifiers to int64

### DIFF
--- a/dnsimple/accounts.go
+++ b/dnsimple/accounts.go
@@ -1,14 +1,12 @@
 package dnsimple
 
-import ()
-
 type AccountsService struct {
 	client *Client
 }
 
 // Account represents a DNSimple account.
 type Account struct {
-	ID             int    `json:"id,omitempty"`
+	ID             int64  `json:"id,omitempty"`
 	Email          string `json:"email,omitempty"`
 	PlanIdentifier string `json:"plan_identifier,omitempty"`
 	CreatedAt      string `json:"created_at,omitempty"`

--- a/dnsimple/accounts_test.go
+++ b/dnsimple/accounts_test.go
@@ -32,7 +32,7 @@ func TestAccountsService_List(t *testing.T) {
 		t.Errorf("Accounts.ListAccounts() expected to return %v accounts, got %v", want, got)
 	}
 
-	if want, got := 123, accounts[0].ID; want != got {
+	if want, got := int64(123), accounts[0].ID; want != got {
 		t.Fatalf("Accounts.ListAccounts() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "john@example.com", accounts[0].Email; want != got {

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -2,7 +2,6 @@ package dnsimple
 
 import (
 	"fmt"
-	"strconv"
 )
 
 // CertificatesService handles communication with the certificate related
@@ -15,9 +14,9 @@ type CertificatesService struct {
 
 // Certificate represents a Certificate in DNSimple.
 type Certificate struct {
-	ID                  int      `json:"id,omitempty"`
-	DomainID            int      `json:"domain_id,omitempty"`
-	ContactID           int      `json:"contact_id,omitempty"`
+	ID                  int64    `json:"id,omitempty"`
+	DomainID            int64    `json:"domain_id,omitempty"`
+	ContactID           int64    `json:"contact_id,omitempty"`
 	CommonName          string   `json:"common_name,omitempty"`
 	AlternateNames      []string `json:"alternate_names,omitempty"`
 	Years               int      `json:"years,omitempty"`
@@ -42,8 +41,8 @@ type CertificateBundle struct {
 
 // CertificatePurchase represents a Certificate Purchase in DNSimple.
 type CertificatePurchase struct {
-	ID            int    `json:"id,omitempty"`
-	CertificateID int    `json:"new_certificate_id,omitempty"`
+	ID            int64  `json:"id,omitempty"`
+	CertificateID int64  `json:"new_certificate_id,omitempty"`
 	State         string `json:"state,omitempty"`
 	AutoRenew     bool   `json:"auto_renew,omitempty"`
 	CreatedAt     string `json:"created_at,omitempty"`
@@ -52,9 +51,9 @@ type CertificatePurchase struct {
 
 // CertificateRenewal represents a Certificate Renewal in DNSimple.
 type CertificateRenewal struct {
-	ID               int    `json:"id,omitempty"`
-	OldCertificateID int    `json:"old_certificate_id,omitempty"`
-	NewCertificateID int    `json:"new_certificate_id,omitempty"`
+	ID               int64  `json:"id,omitempty"`
+	OldCertificateID int64  `json:"old_certificate_id,omitempty"`
+	NewCertificateID int64  `json:"new_certificate_id,omitempty"`
 	State            string `json:"state,omitempty"`
 	AutoRenew        bool   `json:"auto_renew,omitempty"`
 	CreatedAt        string `json:"created_at,omitempty"`
@@ -63,23 +62,23 @@ type CertificateRenewal struct {
 
 // LetsencryptCertificateAttributes is a set of attributes to purchase a Let's Encrypt certificate.
 type LetsencryptCertificateAttributes struct {
-	ContactID      string   `json:"contact_id,omitempty"`
+	ContactID      int64    `json:"contact_id,omitempty"`
 	Name           string   `json:"name,omitempty"`
 	AutoRenew      bool     `json:"auto_renew,omitempty"`
 	AlternateNames []string `json:"alternate_names,omitempty"`
 }
 
-func certificatePath(accountID, domainIdentifier, certificateID string) (path string) {
+func certificatePath(accountID, domainIdentifier string, certificateID int64) (path string) {
 	path = fmt.Sprintf("%v/certificates", domainPath(accountID, domainIdentifier))
-	if certificateID != "" {
+	if certificateID != 0 {
 		path += fmt.Sprintf("/%v", certificateID)
 	}
 	return
 }
 
-func letsencryptCertificatePath(accountID, domainIdentifier, certificateID string) (path string) {
+func letsencryptCertificatePath(accountID, domainIdentifier string, certificateID int64) (path string) {
 	path = fmt.Sprintf("%v/certificates/letsencrypt", domainPath(accountID, domainIdentifier))
-	if certificateID != "" {
+	if certificateID != 0 {
 		path += fmt.Sprintf("/%v", certificateID)
 	}
 	return
@@ -119,7 +118,7 @@ type certificateRenewalResponse struct {
 //
 // See https://developer.dnsimple.com/v2/certificates#listCertificates
 func (s *CertificatesService) ListCertificates(accountID, domainIdentifier string, options *ListOptions) (*certificatesResponse, error) {
-	path := versioned(certificatePath(accountID, domainIdentifier, ""))
+	path := versioned(certificatePath(accountID, domainIdentifier, 0))
 	certificatesResponse := &certificatesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -139,8 +138,8 @@ func (s *CertificatesService) ListCertificates(accountID, domainIdentifier strin
 // GetCertificate gets the details of a certificate.
 //
 // See https://developer.dnsimple.com/v2/certificates#getCertificate
-func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string, certificateID int) (*certificateResponse, error) {
-	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)))
+func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string, certificateID int64) (*certificateResponse, error) {
+	path := versioned(certificatePath(accountID, domainIdentifier, certificateID))
 	certificateResponse := &certificateResponse{}
 
 	resp, err := s.client.get(path, certificateResponse)
@@ -156,8 +155,8 @@ func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string,
 // along with the root certificate and intermediate chain.
 //
 // See https://developer.dnsimple.com/v2/certificates#downloadCertificate
-func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier string, certificateID int) (*certificateBundleResponse, error) {
-	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + "/download")
+func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier string, certificateID int64) (*certificateBundleResponse, error) {
+	path := versioned(certificatePath(accountID, domainIdentifier, certificateID) + "/download")
 	certificateBundleResponse := &certificateBundleResponse{}
 
 	resp, err := s.client.get(path, certificateBundleResponse)
@@ -172,8 +171,8 @@ func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier st
 // GetCertificatePrivateKey gets the PEM-encoded certificate private key.
 //
 // See https://developer.dnsimple.com/v2/certificates#getCertificatePrivateKey
-func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifier string, certificateID int) (*certificateBundleResponse, error) {
-	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + "/private_key")
+func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifier string, certificateID int64) (*certificateBundleResponse, error) {
+	path := versioned(certificatePath(accountID, domainIdentifier, certificateID) + "/private_key")
 	certificateBundleResponse := &certificateBundleResponse{}
 
 	resp, err := s.client.get(path, certificateBundleResponse)
@@ -189,7 +188,7 @@ func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifi
 //
 // See https://developer.dnsimple.com/v2/certificates/#purchaseLetsencryptCertificate
 func (s *CertificatesService) PurchaseLetsencryptCertificate(accountID, domainIdentifier string, certificateAttributes LetsencryptCertificateAttributes) (*certificatePurchaseResponse, error) {
-	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, ""))
+	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, 0))
 	certificatePurchaseResponse := &certificatePurchaseResponse{}
 
 	resp, err := s.client.post(path, certificateAttributes, certificatePurchaseResponse)
@@ -204,8 +203,8 @@ func (s *CertificatesService) PurchaseLetsencryptCertificate(accountID, domainId
 // IssueLetsencryptCertificate issues a pending Let's Encrypt certificate purchase order.
 //
 // See https://developer.dnsimple.com/v2/certificates/#issueLetsencryptCertificate
-func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdentifier string, certificateID int) (*certificateResponse, error) {
-	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + "/issue")
+func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdentifier string, certificateID int64) (*certificateResponse, error) {
+	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + "/issue")
 	certificateResponse := &certificateResponse{}
 
 	resp, err := s.client.post(path, nil, certificateResponse)
@@ -220,8 +219,8 @@ func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdent
 // PurchaseLetsencryptCertificateRenewal purchases a Let's Encrypt certificate renewal.
 //
 // See https://developer.dnsimple.com/v2/certificates/#purchaseRenewalLetsencryptCertificate
-func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID int, certificateAttributes LetsencryptCertificateAttributes) (*certificateRenewalResponse, error) {
-	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + "/renewals")
+func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID int64, certificateAttributes LetsencryptCertificateAttributes) (*certificateRenewalResponse, error) {
+	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + "/renewals")
 	certificateRenewalResponse := &certificateRenewalResponse{}
 
 	resp, err := s.client.post(path, certificateAttributes, certificateRenewalResponse)
@@ -236,8 +235,8 @@ func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, d
 // IssueLetsencryptCertificateRenewal issues a pending Let's Encrypt certificate renewal order.
 //
 // See https://developer.dnsimple.com/v2/certificates/#issueRenewalLetsencryptCertificate
-func (s *CertificatesService) IssueLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID, certificateRenewalID int) (*certificateResponse, error) {
-	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + fmt.Sprintf("/renewals/%s/issue", strconv.Itoa(certificateRenewalID)))
+func (s *CertificatesService) IssueLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID, certificateRenewalID int64) (*certificateResponse, error) {
+	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + fmt.Sprintf("/renewals/%d/issue", certificateRenewalID))
 	certificateResponse := &certificateResponse{}
 
 	resp, err := s.client.post(path, nil, certificateResponse)

--- a/dnsimple/certificates_test.go
+++ b/dnsimple/certificates_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestCertificatePath(t *testing.T) {
-	if want, got := "/1010/domains/example.com/certificates", certificatePath("1010", "example.com", ""); want != got {
+	if want, got := "/1010/domains/example.com/certificates", certificatePath("1010", "example.com", 0); want != got {
 		t.Errorf("certificatePath(%v) = %v, want %v", "", got, want)
 	}
 
-	if want, got := "/1010/domains/example.com/certificates/2", certificatePath("1010", "example.com", "2"); want != got {
+	if want, got := "/1010/domains/example.com/certificates/2", certificatePath("1010", "example.com", 2); want != got {
 		t.Errorf("certificatePath(%v) = %v, want %v", "2", got, want)
 	}
 }
@@ -46,7 +46,7 @@ func TestCertificatesService_ListCertificates(t *testing.T) {
 		t.Errorf("Certificates.ListCertificates() expected to return %v contacts, got %v", want, got)
 	}
 
-	if want, got := 1, certificates[0].ID; want != got {
+	if want, got := int64(1), certificates[0].ID; want != got {
 		t.Fatalf("Certificates.ListCertificates() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "www.weppos.net", certificates[0].CommonName; want != got {
@@ -185,14 +185,14 @@ func TestCertificates_LetsencryptPurchase(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"contact_id": "100"}
+		want := map[string]interface{}{"contact_id": float64(100)}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		io.Copy(w, httpResponse.Body)
 	})
 
-	certificateAttributes := LetsencryptCertificateAttributes{ContactID: "100"}
+	certificateAttributes := LetsencryptCertificateAttributes{ContactID: 100}
 
 	certificateResponse, err := client.Certificates.PurchaseLetsencryptCertificate("1010", "example.com", certificateAttributes)
 	if err != nil {
@@ -200,7 +200,7 @@ func TestCertificates_LetsencryptPurchase(t *testing.T) {
 	}
 
 	certificatePurchase := certificateResponse.Data
-	if want, got := 300, certificatePurchase.ID; want != got {
+	if want, got := int64(300), certificatePurchase.ID; want != got {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificate() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 }
@@ -215,14 +215,14 @@ func TestCertificates_LetsencryptPurchaseWithAttributes(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"contact_id": "100", "name": "www", "auto_renew": true, "alternate_names": []interface{}{"api.example.com", "status.example.com"}}
+		want := map[string]interface{}{"contact_id": float64(100), "name": "www", "auto_renew": true, "alternate_names": []interface{}{"api.example.com", "status.example.com"}}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		io.Copy(w, httpResponse.Body)
 	})
 
-	certificateAttributes := LetsencryptCertificateAttributes{ContactID: "100", Name: "www", AutoRenew: true, AlternateNames: []string{"api.example.com", "status.example.com"}}
+	certificateAttributes := LetsencryptCertificateAttributes{ContactID: 100, Name: "www", AutoRenew: true, AlternateNames: []string{"api.example.com", "status.example.com"}}
 
 	_, err := client.Certificates.PurchaseLetsencryptCertificate("1010", "example.com", certificateAttributes)
 	if err != nil {
@@ -250,7 +250,7 @@ func TestCertificates_LetsencryptIssue(t *testing.T) {
 	}
 
 	certificate := certificateResponse.Data
-	if want, got := 200, certificate.ID; want != got {
+	if want, got := int64(200), certificate.ID; want != got {
 		t.Fatalf("Certificates.IssueLetsencryptCertificate() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "www.example.com", certificate.CommonName; want != got {
@@ -280,13 +280,13 @@ func TestCertificates_LetsencryptPurchaseRenewal(t *testing.T) {
 	}
 
 	certificateRenewal := certificateRenewalResponse.Data
-	if want, got := 999, certificateRenewal.ID; want != got {
+	if want, got := int64(999), certificateRenewal.ID; want != got {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificateRenewal() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 200, certificateRenewal.OldCertificateID; want != got {
+	if want, got := int64(200), certificateRenewal.OldCertificateID; want != got {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificateRenewal() returned OldCertificateID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 300, certificateRenewal.NewCertificateID; want != got {
+	if want, got := int64(300), certificateRenewal.NewCertificateID; want != got {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificateRenewal() returned NewCertificateID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "new", certificateRenewal.State; want != got {
@@ -319,13 +319,13 @@ func TestCertificates_LetsencryptPurchaseRenewalWithAttributes(t *testing.T) {
 	}
 
 	certificateRenewal := certificateRenewalResponse.Data
-	if want, got := 999, certificateRenewal.ID; want != got {
+	if want, got := int64(999), certificateRenewal.ID; want != got {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificateRenewal() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 200, certificateRenewal.OldCertificateID; want != got {
+	if want, got := int64(200), certificateRenewal.OldCertificateID; want != got {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificateRenewal() returned OldCertificateID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 300, certificateRenewal.NewCertificateID; want != got {
+	if want, got := int64(300), certificateRenewal.NewCertificateID; want != got {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificateRenewal() returned NewCertificateID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "new", certificateRenewal.State; want != got {
@@ -353,7 +353,7 @@ func TestCertificates_LetsencryptIssueRenewal(t *testing.T) {
 	}
 
 	certificate := certificateResponse.Data
-	if want, got := 300, certificate.ID; want != got {
+	if want, got := int64(300), certificate.ID; want != got {
 		t.Fatalf("Certificates.IssueLetsencryptCertificateRenewal() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "www.example.com", certificate.CommonName; want != got {

--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -14,8 +14,8 @@ type ContactsService struct {
 
 // Contact represents a Contact in DNSimple.
 type Contact struct {
-	ID            int    `json:"id,omitempty"`
-	AccountID     int    `json:"account_id,omitempty"`
+	ID            int64  `json:"id,omitempty"`
+	AccountID     int64  `json:"account_id,omitempty"`
 	Label         string `json:"label,omitempty"`
 	FirstName     string `json:"first_name,omitempty"`
 	LastName      string `json:"last_name,omitempty"`
@@ -34,7 +34,7 @@ type Contact struct {
 	UpdatedAt     string `json:"updated_at,omitempty"`
 }
 
-func contactPath(accountID string, contactID int) (path string) {
+func contactPath(accountID string, contactID int64) (path string) {
 	path = fmt.Sprintf("/%v/contacts", accountID)
 	if contactID != 0 {
 		path += fmt.Sprintf("/%v", contactID)
@@ -94,7 +94,7 @@ func (s *ContactsService) CreateContact(accountID string, contactAttributes Cont
 // GetContact fetches a contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#get
-func (s *ContactsService) GetContact(accountID string, contactID int) (*contactResponse, error) {
+func (s *ContactsService) GetContact(accountID string, contactID int64) (*contactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &contactResponse{}
 
@@ -110,7 +110,7 @@ func (s *ContactsService) GetContact(accountID string, contactID int) (*contactR
 // UpdateContact updates a contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#update
-func (s *ContactsService) UpdateContact(accountID string, contactID int, contactAttributes Contact) (*contactResponse, error) {
+func (s *ContactsService) UpdateContact(accountID string, contactID int64, contactAttributes Contact) (*contactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &contactResponse{}
 
@@ -126,7 +126,7 @@ func (s *ContactsService) UpdateContact(accountID string, contactID int, contact
 // DeleteContact PERMANENTLY deletes a contact from the account.
 //
 // See https://developer.dnsimple.com/v2/contacts/#delete
-func (s *ContactsService) DeleteContact(accountID string, contactID int) (*contactResponse, error) {
+func (s *ContactsService) DeleteContact(accountID string, contactID int64) (*contactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &contactResponse{}
 

--- a/dnsimple/contacts_test.go
+++ b/dnsimple/contacts_test.go
@@ -47,7 +47,7 @@ func TestContactsService_List(t *testing.T) {
 		t.Errorf("Contacts.ListContacts() expected to return %v contacts, got %v", want, got)
 	}
 
-	if want, got := 1, contacts[0].ID; want != got {
+	if want, got := int64(1), contacts[0].ID; want != got {
 		t.Fatalf("Contacts.ListContacts() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "Default", contacts[0].Label; want != got {
@@ -100,7 +100,7 @@ func TestContactsService_Create(t *testing.T) {
 	}
 
 	contact := contactResponse.Data
-	if want, got := 1, contact.ID; want != got {
+	if want, got := int64(1), contact.ID; want != got {
 		t.Fatalf("Contacts.CreateContact() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "Default", contact.Label; want != got {
@@ -123,7 +123,7 @@ func TestContactsService_Get(t *testing.T) {
 	})
 
 	accountID := "1010"
-	contactID := 1
+	contactID := int64(1)
 
 	contactResponse, err := client.Contacts.GetContact(accountID, contactID)
 	if err != nil {
@@ -174,7 +174,7 @@ func TestContactsService_Update(t *testing.T) {
 
 	contactAttributes := Contact{Label: "Default"}
 	accountID := "1010"
-	contactID := 1
+	contactID := int64(1)
 
 	contactResponse, err := client.Contacts.UpdateContact(accountID, contactID, contactAttributes)
 	if err != nil {
@@ -182,7 +182,7 @@ func TestContactsService_Update(t *testing.T) {
 	}
 
 	contact := contactResponse.Data
-	if want, got := 1, contact.ID; want != got {
+	if want, got := int64(1), contact.ID; want != got {
 		t.Fatalf("Contacts.UpdateContact() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "Default", contact.Label; want != got {
@@ -205,7 +205,7 @@ func TestContactsService_Delete(t *testing.T) {
 	})
 
 	accountID := "1010"
-	contactID := 1
+	contactID := int64(1)
 
 	_, err := client.Contacts.DeleteContact(accountID, contactID)
 	if err != nil {

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -14,9 +14,9 @@ type DomainsService struct {
 
 // Domain represents a domain in DNSimple.
 type Domain struct {
-	ID           int    `json:"id,omitempty"`
-	AccountID    int    `json:"account_id,omitempty"`
-	RegistrantID int    `json:"registrant_id,omitempty"`
+	ID           int64  `json:"id,omitempty"`
+	AccountID    int64  `json:"account_id,omitempty"`
+	RegistrantID int64  `json:"registrant_id,omitempty"`
 	Name         string `json:"name,omitempty"`
 	UnicodeName  string `json:"unicode_name,omitempty"`
 	Token        string `json:"token,omitempty"`

--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -6,10 +6,10 @@ import (
 
 // Collaborator represents a Collaborator in DNSimple.
 type Collaborator struct {
-	ID         int    `json:"id,omitempty"`
-	DomainID   int    `json:"domain_id,omitempty"`
+	ID         int64  `json:"id,omitempty"`
+	DomainID   int64  `json:"domain_id,omitempty"`
 	DomainName string `json:"domain_name,omitempty"`
-	UserID     int    `json:"user_id,omitempty"`
+	UserID     int64  `json:"user_id,omitempty"`
 	UserEmail  string `json:"user_email,omitempty"`
 	Invitation bool   `json:"invitation,omitempty"`
 	CreatedAt  string `json:"created_at,omitempty"`
@@ -17,7 +17,7 @@ type Collaborator struct {
 	AcceptedAt string `json:"accepted_at,omitempty"`
 }
 
-func collaboratorPath(accountID, domainIdentifier string, collaboratorID int) (path string) {
+func collaboratorPath(accountID, domainIdentifier string, collaboratorID int64) (path string) {
 	path = fmt.Sprintf("%v/collaborators", domainPath(accountID, domainIdentifier))
 	if collaboratorID != 0 {
 		path += fmt.Sprintf("/%v", collaboratorID)
@@ -66,7 +66,7 @@ func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, o
 // AddCollaborator adds a new collaborator to the domain in the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*collaboratorResponse, error) {
+func (s *DomainsService) AddCollaborator(accountID, domainIdentifier string, attributes CollaboratorAttributes) (*collaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
 	collaboratorResponse := &collaboratorResponse{}
 
@@ -81,8 +81,8 @@ func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier stri
 
 // RemoveCollaborator PERMANENTLY deletes a domain from the account.
 //
-// See https://developer.dnsimple.com/v2/domains/collaborators#remove
-func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID int) (*collaboratorResponse, error) {
+// See https://developer.dnsimple.com/v2/domains/collaborators#add
+func (s *DomainsService) RemoveCollaborator(accountID, domainIdentifier string, collaboratorID int64) (*collaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
 	collaboratorResponse := &collaboratorResponse{}
 

--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -17,9 +17,9 @@ type Collaborator struct {
 	AcceptedAt string `json:"accepted_at,omitempty"`
 }
 
-func collaboratorPath(accountID, domainIdentifier, collaboratorID string) (path string) {
+func collaboratorPath(accountID, domainIdentifier string, collaboratorID int) (path string) {
 	path = fmt.Sprintf("%v/collaborators", domainPath(accountID, domainIdentifier))
-	if collaboratorID != "" {
+	if collaboratorID != 0 {
 		path += fmt.Sprintf("/%v", collaboratorID)
 	}
 	return
@@ -46,7 +46,7 @@ type collaboratorsResponse struct {
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#list
 func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*collaboratorsResponse, error) {
-	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
+	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
 	collaboratorsResponse := &collaboratorsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -67,7 +67,7 @@ func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, o
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
 func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*collaboratorResponse, error) {
-	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
+	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
 	collaboratorResponse := &collaboratorResponse{}
 
 	resp, err := s.client.post(path, attributes, collaboratorResponse)
@@ -81,8 +81,8 @@ func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier stri
 
 // RemoveCollaborator PERMANENTLY deletes a domain from the account.
 //
-// See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID string) (*collaboratorResponse, error) {
+// See https://developer.dnsimple.com/v2/domains/collaborators#remove
+func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID int) (*collaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
 	collaboratorResponse := &collaboratorResponse{}
 

--- a/dnsimple/domains_collaborators_test.go
+++ b/dnsimple/domains_collaborators_test.go
@@ -46,13 +46,13 @@ func TestDomainsService_ListCollaborators(t *testing.T) {
 		t.Errorf("Domains.ListCollaborators() expected to return %v collaborators, got %v", want, got)
 	}
 
-	if want, got := 100, collaborators[0].ID; want != got {
+	if want, got := int64(100), collaborators[0].ID; want != got {
 		t.Fatalf("Domains.ListCollaborators() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example.com", collaborators[0].DomainName; want != got {
 		t.Fatalf("Domains.ListCollaborators() returned DomainName expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 999, collaborators[0].UserID; want != got {
+	if want, got := int64(999), collaborators[0].UserID; want != got {
 		t.Fatalf("Domains.ListCollaborators() returned UserID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := false, collaborators[0].Invitation; want != got {
@@ -106,7 +106,7 @@ func TestDomainsService_AddCollaborator(t *testing.T) {
 	}
 
 	collaborator := collaboratorResponse.Data
-	if want, got := 100, collaborator.ID; want != got {
+	if want, got := int64(100), collaborator.ID; want != got {
 		t.Fatalf("Domains.AddCollaborator() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example.com", collaborator.DomainName; want != got {
@@ -147,7 +147,7 @@ func TestDomainsService_AddNonExistingCollaborator(t *testing.T) {
 	}
 
 	collaborator := collaboratorResponse.Data
-	if want, got := 101, collaborator.ID; want != got {
+	if want, got := int64(101), collaborator.ID; want != got {
 		t.Fatalf("Domains.AddCollaborator() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example.com", collaborator.DomainName; want != got {
@@ -177,7 +177,7 @@ func TestDomainsService_RemoveCollaborator(t *testing.T) {
 
 	accountID := "1010"
 	domainID := "example.com"
-	collaboratorID := 100
+	collaboratorID := int64(100)
 
 	_, err := client.Domains.RemoveCollaborator(accountID, domainID, collaboratorID)
 	if err != nil {

--- a/dnsimple/domains_collaborators_test.go
+++ b/dnsimple/domains_collaborators_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestCollaboratorPath(t *testing.T) {
-	if want, got := "/1010/domains/example.com/collaborators", collaboratorPath("1010", "example.com", ""); want != got {
+	if want, got := "/1010/domains/example.com/collaborators", collaboratorPath("1010", "example.com", 0); want != got {
 		t.Errorf("collaboratorPath(%v) = %v, want %v", "", got, want)
 	}
 
-	if want, got := "/1010/domains/example.com/collaborators/2", collaboratorPath("1010", "example.com", "2"); want != got {
+	if want, got := "/1010/domains/example.com/collaborators/2", collaboratorPath("1010", "example.com", 2); want != got {
 		t.Errorf("collaboratorPath(%v) = %v, want %v", "2", got, want)
 	}
 }
@@ -177,9 +177,9 @@ func TestDomainsService_RemoveCollaborator(t *testing.T) {
 
 	accountID := "1010"
 	domainID := "example.com"
-	contactID := "100"
+	collaboratorID := 100
 
-	_, err := client.Domains.RemoveCollaborator(accountID, domainID, contactID)
+	_, err := client.Domains.RemoveCollaborator(accountID, domainID, collaboratorID)
 	if err != nil {
 		t.Fatalf("Domains.RemoveCollaborator() returned error: %v", err)
 	}

--- a/dnsimple/domains_delegation_signer_records.go
+++ b/dnsimple/domains_delegation_signer_records.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // DelegationSignerRecord represents a delegation signer record for a domain in DNSimple.
 type DelegationSignerRecord struct {
-	ID         int    `json:"id,omitempty"`
-	DomainID   int    `json:"domain_id,omitempty"`
+	ID         int64  `json:"id,omitempty"`
+	DomainID   int64  `json:"domain_id,omitempty"`
 	Algorithm  string `json:"algorithm"`
 	Digest     string `json:"digest"`
 	DigestType string `json:"digest_type"`
@@ -14,10 +14,10 @@ type DelegationSignerRecord struct {
 	UpdatedAt  string `json:"updated_at,omitempty"`
 }
 
-func delegationSignerRecordPath(accountID string, domainIdentifier string, dsRecordID int) (path string) {
+func delegationSignerRecordPath(accountID string, domainIdentifier string, dsRecordID int64) (path string) {
 	path = fmt.Sprintf("%v/ds_records", domainPath(accountID, domainIdentifier))
 	if dsRecordID != 0 {
-		path += fmt.Sprintf("/%d", dsRecordID)
+		path += fmt.Sprintf("/%v", dsRecordID)
 	}
 	return
 }
@@ -74,7 +74,7 @@ func (s *DomainsService) CreateDelegationSignerRecord(accountID string, domainId
 // GetDelegationSignerRecord fetches a delegation signer record.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-get
-func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int) (*delegationSignerRecordResponse, error) {
+func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int64) (*delegationSignerRecordResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
 	dsRecordResponse := &delegationSignerRecordResponse{}
 
@@ -91,7 +91,7 @@ func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdent
 // from the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-delete
-func (s *DomainsService) DeleteDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int) (*delegationSignerRecordResponse, error) {
+func (s *DomainsService) DeleteDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int64) (*delegationSignerRecordResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
 	dsRecordResponse := &delegationSignerRecordResponse{}
 

--- a/dnsimple/domains_delegation_signer_records_test.go
+++ b/dnsimple/domains_delegation_signer_records_test.go
@@ -46,7 +46,7 @@ func TestDomainsService_ListDelegationSignerRecords(t *testing.T) {
 		t.Errorf("Domains.ListDelegationSignerRecords() expected to return %v delegation signer records, got %v", want, got)
 	}
 
-	if want, got := 24, dsRecords[0].ID; want != got {
+	if want, got := int64(24), dsRecords[0].ID; want != got {
 		t.Fatalf("Domains.ListDelegationSignerRecords() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "8", dsRecords[0].Algorithm; want != got {
@@ -98,7 +98,7 @@ func TestDomainsService_CreateDelegationSignerRecord(t *testing.T) {
 	}
 
 	dsRecord := dsRecordResponse.Data
-	if want, got := 2, dsRecord.ID; want != got {
+	if want, got := int64(2), dsRecord.ID; want != got {
 		t.Fatalf("Domains.CreateDelegationSignerRecord() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "13", dsRecord.Algorithm; want != got {

--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -1,6 +1,8 @@
 package dnsimple
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Dnssec represents the current DNSSEC settings for a domain in DNSimple.
 type Dnssec struct {

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -6,18 +6,18 @@ import (
 
 // EmailForward represents an email forward in DNSimple.
 type EmailForward struct {
-	ID        int    `json:"id,omitempty"`
-	DomainID  int    `json:"domain_id,omitempty"`
+	ID        int64  `json:"id,omitempty"`
+	DomainID  int64  `json:"domain_id,omitempty"`
 	From      string `json:"from,omitempty"`
 	To        string `json:"to,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-func emailForwardPath(accountID string, domainIdentifier string, forwardID int) (path string) {
+func emailForwardPath(accountID string, domainIdentifier string, forwardID int64) (path string) {
 	path = fmt.Sprintf("%v/email_forwards", domainPath(accountID, domainIdentifier))
 	if forwardID != 0 {
-		path += fmt.Sprintf("/%d", forwardID)
+		path += fmt.Sprintf("/%v", forwardID)
 	}
 	return
 }
@@ -74,7 +74,7 @@ func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier s
 // GetEmailForward fetches an email forward.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#get
-func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier string, forwardID int) (*emailForwardResponse, error) {
+func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier string, forwardID int64) (*emailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
 	forwardResponse := &emailForwardResponse{}
 
@@ -90,7 +90,7 @@ func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier stri
 // DeleteEmailForward PERMANENTLY deletes an email forward from the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#delete
-func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier string, forwardID int) (*emailForwardResponse, error) {
+func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier string, forwardID int64) (*emailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
 	forwardResponse := &emailForwardResponse{}
 

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -49,7 +49,7 @@ func TestDomainsService_EmailForwardsList(t *testing.T) {
 		t.Errorf("Domains.ListEmailForwards() expected to return %v contacts, got %v", want, got)
 	}
 
-	if want, got := 17702, forwards[0].ID; want != got {
+	if want, got := int64(17702), forwards[0].ID; want != got {
 		t.Fatalf("Domains.ListEmailForwards() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if !regexpEmail.MatchString(forwards[0].From) {
@@ -101,7 +101,7 @@ func TestDomainsService_CreateEmailForward(t *testing.T) {
 	}
 
 	forward := forwardResponse.Data
-	if want, got := 17706, forward.ID; want != got {
+	if want, got := int64(17706), forward.ID; want != got {
 		t.Fatalf("Domains.CreateEmailForward() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if !regexpEmail.MatchString(forward.From) {

--- a/dnsimple/domains_pushes.go
+++ b/dnsimple/domains_pushes.go
@@ -6,19 +6,19 @@ import (
 
 // DomainPush represents a domain push in DNSimple.
 type DomainPush struct {
-	ID         int    `json:"id,omitempty"`
-	DomainID   int    `json:"domain_id,omitempty"`
-	ContactID  int    `json:"contact_id,omitempty"`
-	AccountID  int    `json:"account_id,omitempty"`
+	ID         int64  `json:"id,omitempty"`
+	DomainID   int64  `json:"domain_id,omitempty"`
+	ContactID  int64  `json:"contact_id,omitempty"`
+	AccountID  int64  `json:"account_id,omitempty"`
 	CreatedAt  string `json:"created_at,omitempty"`
 	UpdatedAt  string `json:"updated_at,omitempty"`
 	AcceptedAt string `json:"accepted_at,omitempty"`
 }
 
-func domainPushPath(accountID string, pushID int) (path string) {
+func domainPushPath(accountID string, pushID int64) (path string) {
 	path = fmt.Sprintf("/%v/pushes", accountID)
 	if pushID != 0 {
-		path += fmt.Sprintf("/%d", pushID)
+		path += fmt.Sprintf("/%v", pushID)
 	}
 	return
 }
@@ -38,13 +38,13 @@ type domainPushesResponse struct {
 // DomainPushAttributes represent a domain push payload (see initiate).
 type DomainPushAttributes struct {
 	NewAccountEmail string `json:"new_account_email,omitempty"`
-	ContactID       string `json:"contact_id,omitempty"`
+	ContactID       int64  `json:"contact_id,omitempty"`
 }
 
 // InitiatePush initiate a new domain push.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#initiate
-func (s *DomainsService) InitiatePush(accountID string, domainID string, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
+func (s *DomainsService) InitiatePush(accountID, domainID string, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/pushes", domainPath(accountID, domainID)))
 	pushResponse := &domainPushResponse{}
 
@@ -81,7 +81,7 @@ func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*do
 // AcceptPush accept a push for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#accept
-func (s *DomainsService) AcceptPush(accountID string, pushID int, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
+func (s *DomainsService) AcceptPush(accountID string, pushID int64, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
 	path := versioned(domainPushPath(accountID, pushID))
 	pushResponse := &domainPushResponse{}
 
@@ -97,7 +97,7 @@ func (s *DomainsService) AcceptPush(accountID string, pushID int, pushAttributes
 // RejectPush reject a push for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#reject
-func (s *DomainsService) RejectPush(accountID string, pushID int) (*domainPushResponse, error) {
+func (s *DomainsService) RejectPush(accountID string, pushID int64) (*domainPushResponse, error) {
 	path := versioned(domainPushPath(accountID, pushID))
 	pushResponse := &domainPushResponse{}
 

--- a/dnsimple/domains_pushes_test.go
+++ b/dnsimple/domains_pushes_test.go
@@ -43,10 +43,10 @@ func TestDomainsService_InitiatePush(t *testing.T) {
 	}
 
 	push := pushResponse.Data
-	if want, got := 1, push.ID; want != got {
+	if want, got := int64(1), push.ID; want != got {
 		t.Fatalf("Domains.InitiatePush() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 2020, push.AccountID; want != got {
+	if want, got := int64(2020), push.AccountID; want != got {
 		t.Fatalf("Domains.InitiatePush() returned Account ID expected to be `%v`, got `%v`", want, got)
 	}
 }
@@ -79,10 +79,10 @@ func TestDomainsService_DomainsPushesList(t *testing.T) {
 		t.Errorf("Domains.ListPushes() expected to return %v pushes, got %v", want, got)
 	}
 
-	if want, got := 1, pushes[0].ID; want != got {
+	if want, got := int64(1), pushes[0].ID; want != got {
 		t.Fatalf("Domains.ListPushes() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 2020, pushes[0].AccountID; want != got {
+	if want, got := int64(2020), pushes[0].AccountID; want != got {
 		t.Fatalf("Domains.ListPushes() returned Account ID expected to be `%v`, got `%v`", want, got)
 	}
 }
@@ -116,14 +116,14 @@ func TestDomainsService_AcceptPush(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"contact_id": "2"}
+		want := map[string]interface{}{"contact_id": float64(2)}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		io.Copy(w, httpResponse.Body)
 	})
 
-	pushAttributes := DomainPushAttributes{ContactID: "2"}
+	pushAttributes := DomainPushAttributes{ContactID: 2}
 
 	_, err := client.Domains.AcceptPush("2020", 1, pushAttributes)
 	if err != nil {

--- a/dnsimple/domains_test.go
+++ b/dnsimple/domains_test.go
@@ -47,7 +47,7 @@ func TestDomainsService_ListDomains(t *testing.T) {
 		t.Errorf("Domains.ListDomains() expected to return %v contacts, got %v", want, got)
 	}
 
-	if want, got := 1, domains[0].ID; want != got {
+	if want, got := int64(1), domains[0].ID; want != got {
 		t.Fatalf("Domains.ListDomains() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example-alpha.com", domains[0].Name; want != got {
@@ -106,7 +106,7 @@ func TestDomainsService_CreateDomain(t *testing.T) {
 	}
 
 	domain := domainResponse.Data
-	if want, got := 1, domain.ID; want != got {
+	if want, got := int64(1), domain.ID; want != got {
 		t.Fatalf("Domains.Create() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example-alpha.com", domain.Name; want != got {
@@ -198,7 +198,7 @@ func TestDomainsService_ResetDomainToken(t *testing.T) {
 	}
 
 	domain := domainResponse.Data
-	if want, got := 1, domain.ID; want != got {
+	if want, got := int64(1), domain.ID; want != got {
 		t.Fatalf("Domains.ResetDomainToken() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example-alpha.com", domain.Name; want != got {

--- a/dnsimple/identity_test.go
+++ b/dnsimple/identity_test.go
@@ -37,7 +37,7 @@ func TestAuthService_Whoami(t *testing.T) {
 
 	account := whoami.Account
 
-	if want, got := 1, account.ID; want != got {
+	if want, got := int64(1), account.ID; want != got {
 		t.Fatalf("Identity.Whoami() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 

--- a/dnsimple/live_test.go
+++ b/dnsimple/live_test.go
@@ -3,7 +3,6 @@ package dnsimple
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 )
@@ -145,9 +144,9 @@ func TestLive_Zones(t *testing.T) {
 		t.Fatalf("Live Zones/Whoami() returned error: %v", err)
 	}
 
-	accountID := strconv.Itoa(whoami.Account.ID)
+	accountID := fmt.Sprintf("%v", whoami.Account.ID)
 
-	domainResponse, err := dnsimpleClient.Domains.CreateDomain(fmt.Sprintf("%v", accountID), Domain{Name: fmt.Sprintf("example-%v.test", time.Now().Unix())})
+	domainResponse, err := dnsimpleClient.Domains.CreateDomain(accountID, Domain{Name: fmt.Sprintf("example-%v.test", time.Now().Unix())})
 	if err != nil {
 		t.Fatalf("Live Zones/CreateZone() returned error: %v", err)
 	}

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -28,7 +28,7 @@ type domainCheckResponse struct {
 // CheckDomain checks a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#check
-func (s *RegistrarService) CheckDomain(accountID, domainName string) (*domainCheckResponse, error) {
+func (s *RegistrarService) CheckDomain(accountID string, domainName string) (*domainCheckResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/check", accountID, domainName))
 	checkResponse := &domainCheckResponse{}
 
@@ -70,7 +70,7 @@ type DomainPremiumPriceOptions struct {
 // - renewal
 //
 // See https://developer.dnsimple.com/v2/registrar/#premium-price
-func (s *RegistrarService) GetDomainPremiumPrice(accountID, domainName string, options *DomainPremiumPriceOptions) (*domainPremiumPriceResponse, error) {
+func (s *RegistrarService) GetDomainPremiumPrice(accountID string, domainName string, options *DomainPremiumPriceOptions) (*domainPremiumPriceResponse, error) {
 	var err error
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/premium_price", accountID, domainName))
 	priceResponse := &domainPremiumPriceResponse{}

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -6,8 +6,8 @@ import (
 
 // WhoisPrivacy represents a whois privacy in DNSimple.
 type WhoisPrivacy struct {
-	ID        int    `json:"id,omitempty"`
-	DomainID  int    `json:"domain_id,omitempty"`
+	ID        int64  `json:"id,omitempty"`
+	DomainID  int64  `json:"domain_id,omitempty"`
 	Enabled   bool   `json:"enabled,omitempty"`
 	ExpiresOn string `json:"expires_on,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`

--- a/dnsimple/registrar_whois_privacy_test.go
+++ b/dnsimple/registrar_whois_privacy_test.go
@@ -63,7 +63,7 @@ func TestRegistrarService_EnableWhoisPrivacy(t *testing.T) {
 	}
 
 	privacy := privacyResponse.Data
-	if want, got := 1, privacy.ID; want != got {
+	if want, got := int64(1), privacy.ID; want != got {
 		t.Fatalf("Registrar.EnableWhoisPrivacy() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 }
@@ -91,7 +91,7 @@ func TestRegistrarService_DisableWhoisPrivacy(t *testing.T) {
 	}
 
 	privacy := privacyResponse.Data
-	if want, got := 1, privacy.ID; want != got {
+	if want, got := int64(1), privacy.ID; want != got {
 		t.Fatalf("Registrar.DisableWhoisPrivacy() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 }

--- a/dnsimple/services.go
+++ b/dnsimple/services.go
@@ -14,7 +14,7 @@ type ServicesService struct {
 
 // Service represents a Service in DNSimple.
 type Service struct {
-	ID               int              `json:"id,omitempty"`
+	ID               int64            `json:"id,omitempty"`
 	SID              string           `json:"sid,omitempty"`
 	Name             string           `json:"name,omitempty"`
 	Description      string           `json:"description,omitempty"`
@@ -36,10 +36,10 @@ type ServiceSetting struct {
 	Password    bool   `json:"password,omitempty"`
 }
 
-func servicePath(serviceID string) (path string) {
+func servicePath(serviceIdentifier string) (path string) {
 	path = "/services"
-	if serviceID != "" {
-		path += fmt.Sprintf("/%v", serviceID)
+	if serviceIdentifier != "" {
+		path += fmt.Sprintf("/%v", serviceIdentifier)
 	}
 	return
 }

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -19,8 +19,8 @@ type DomainServiceSettings struct {
 // AppliedServices lists the applied one-click services for a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#applied
-func (s *ServicesService) AppliedServices(accountID string, domainID string, options *ListOptions) (*servicesResponse, error) {
-	path := versioned(domainServicesPath(accountID, domainID, ""))
+func (s *ServicesService) AppliedServices(accountID string, domainIdentifier string, options *ListOptions) (*servicesResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainIdentifier, ""))
 	servicesResponse := &servicesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -40,8 +40,8 @@ func (s *ServicesService) AppliedServices(accountID string, domainID string, opt
 // ApplyService applies a one-click services to a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#apply
-func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainID string, settings DomainServiceSettings) (*serviceResponse, error) {
-	path := versioned(domainServicesPath(accountID, domainID, serviceIdentifier))
+func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainIdentifier string, settings DomainServiceSettings) (*serviceResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
 	serviceResponse := &serviceResponse{}
 
 	resp, err := s.client.post(path, settings, nil)
@@ -56,8 +56,8 @@ func (s *ServicesService) ApplyService(accountID string, serviceIdentifier strin
 // UnapplyService unapplies a one-click services from a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#unapply
-func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainID string) (*serviceResponse, error) {
-	path := versioned(domainServicesPath(accountID, domainID, serviceIdentifier))
+func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainIdentifier string) (*serviceResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
 	serviceResponse := &serviceResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 )
 
-func domainServicesPath(accountID string, domainID string, serviceIdentifier string) string {
+func domainServicesPath(accountID string, domainIdentifier string, serviceIdentifier string) string {
 	if serviceIdentifier != "" {
-		return fmt.Sprintf("/%v/domains/%v/services/%v", accountID, domainID, serviceIdentifier)
+		return fmt.Sprintf("/%v/domains/%v/services/%v", accountID, domainIdentifier, serviceIdentifier)
 	}
-	return fmt.Sprintf("/%v/domains/%v/services", accountID, domainID)
+	return fmt.Sprintf("/%v/domains/%v/services", accountID, domainIdentifier)
 }
 
 // DomainServiceSettings represents optional settings when applying a DNSimple one-click service to a domain.

--- a/dnsimple/services_domains_test.go
+++ b/dnsimple/services_domains_test.go
@@ -47,7 +47,7 @@ func TestServicesService_AppliedServices(t *testing.T) {
 		t.Errorf("DomainServices.AppliedServices() expected to return %v services, got %v", want, got)
 	}
 
-	if want, got := 1, services[0].ID; want != got {
+	if want, got := int64(1), services[0].ID; want != got {
 		t.Fatalf("DomainServices.AppliedServices() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "wordpress", services[0].SID; want != got {

--- a/dnsimple/services_test.go
+++ b/dnsimple/services_test.go
@@ -47,7 +47,7 @@ func TestServicesService_List(t *testing.T) {
 		t.Errorf("Services.ListServices() expected to return %v services, got %v", want, got)
 	}
 
-	if want, got := 1, services[0].ID; want != got {
+	if want, got := int64(1), services[0].ID; want != got {
 		t.Fatalf("Services.ListServices() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "Service 1", services[0].Name; want != got {

--- a/dnsimple/templates.go
+++ b/dnsimple/templates.go
@@ -14,9 +14,9 @@ type TemplatesService struct {
 
 // Template represents a Template in DNSimple.
 type Template struct {
-	ID          int    `json:"id,omitempty"`
+	ID          int64  `json:"id,omitempty"`
 	SID         string `json:"sid,omitempty"`
-	AccountID   int    `json:"account_id,omitempty"`
+	AccountID   int64  `json:"account_id,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
 	CreatedAt   string `json:"created_at,omitempty"`

--- a/dnsimple/templates_domains.go
+++ b/dnsimple/templates_domains.go
@@ -7,8 +7,8 @@ import (
 // ApplyTemplate applies a template to the given domain.
 //
 // See https://developer.dnsimple.com/v2/templates/domains/#apply
-func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier string, domainID string) (*templateResponse, error) {
-	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath(accountID, domainID), templateIdentifier))
+func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier string, domainIdentifier string) (*templateResponse, error) {
+	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath(accountID, domainIdentifier), templateIdentifier))
 	templateResponse := &templateResponse{}
 
 	resp, err := s.client.post(path, nil, nil)

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -17,8 +17,8 @@ type TemplateRecord struct {
 	UpdatedAt  string `json:"updated_at,omitempty"`
 }
 
-func templateRecordPath(accountID string, templateIdentifier string, templateRecordID string) string {
-	if templateRecordID != "" {
+func templateRecordPath(accountID string, templateIdentifier string, templateRecordID int) string {
+	if templateRecordID != 0 {
 		return fmt.Sprintf("%v/records/%v", templatePath(accountID, templateIdentifier), templateRecordID)
 	}
 
@@ -41,7 +41,7 @@ type templateRecordsResponse struct {
 //
 // See https://developer.dnsimple.com/v2/templates/records/#list
 func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentifier string, options *ListOptions) (*templateRecordsResponse, error) {
-	path := versioned(templateRecordPath(accountID, templateIdentifier, ""))
+	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
 	templateRecordsResponse := &templateRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -62,7 +62,7 @@ func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentif
 //
 // See https://developer.dnsimple.com/v2/templates/records/#create
 func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*templateRecordResponse, error) {
-	path := versioned(templateRecordPath(accountID, templateIdentifier, ""))
+	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
 	templateRecordResponse := &templateRecordResponse{}
 
 	resp, err := s.client.post(path, templateRecordAttributes, templateRecordResponse)
@@ -77,7 +77,7 @@ func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdenti
 // GetTemplateRecord fetches a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#get
-func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*templateRecordResponse, error) {
+func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID int) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &templateRecordResponse{}
 
@@ -93,7 +93,7 @@ func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifie
 // DeleteTemplateRecord deletes a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#delete
-func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*templateRecordResponse, error) {
+func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID int) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &templateRecordResponse{}
 

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -6,8 +6,8 @@ import (
 
 // TemplateRecord represents a DNS record for a template in DNSimple.
 type TemplateRecord struct {
-	ID         int    `json:"id,omitempty"`
-	TemplateID int    `json:"template_id,omitempty"`
+	ID         int64  `json:"id,omitempty"`
+	TemplateID int64  `json:"template_id,omitempty"`
 	Name       string `json:"name"`
 	Content    string `json:"content,omitempty"`
 	TTL        int    `json:"ttl,omitempty"`
@@ -17,7 +17,7 @@ type TemplateRecord struct {
 	UpdatedAt  string `json:"updated_at,omitempty"`
 }
 
-func templateRecordPath(accountID string, templateIdentifier string, templateRecordID int) string {
+func templateRecordPath(accountID string, templateIdentifier string, templateRecordID int64) string {
 	if templateRecordID != 0 {
 		return fmt.Sprintf("%v/records/%v", templatePath(accountID, templateIdentifier), templateRecordID)
 	}
@@ -77,7 +77,7 @@ func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdenti
 // GetTemplateRecord fetches a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#get
-func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID int) (*templateRecordResponse, error) {
+func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID int64) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &templateRecordResponse{}
 
@@ -93,7 +93,7 @@ func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifie
 // DeleteTemplateRecord deletes a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#delete
-func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID int) (*templateRecordResponse, error) {
+func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID int64) (*templateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &templateRecordResponse{}
 

--- a/dnsimple/templates_records_test.go
+++ b/dnsimple/templates_records_test.go
@@ -47,7 +47,7 @@ func TestTemplatesService_ListTemplateRecords(t *testing.T) {
 		t.Errorf("Templates.ListTemplateRecords() expected to return %v templates, got %v", want, got)
 	}
 
-	if want, got := 296, templates[0].ID; want != got {
+	if want, got := int64(296), templates[0].ID; want != got {
 		t.Fatalf("Templates.ListTemplateRecords() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "192.168.1.1", templates[0].Content; want != got {
@@ -99,7 +99,7 @@ func TestTemplatesService_CreateTemplateRecord(t *testing.T) {
 	}
 
 	templateRecord := templateRecordResponse.Data
-	if want, got := 300, templateRecord.ID; want != got {
+	if want, got := int64(300), templateRecord.ID; want != got {
 		t.Fatalf("Templates.CreateTemplateRecord() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "mx.example.com", templateRecord.Content; want != got {

--- a/dnsimple/templates_records_test.go
+++ b/dnsimple/templates_records_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestTemplates_templateRecordPath(t *testing.T) {
-	if want, got := "/1010/templates/1/records", templateRecordPath("1010", "1", ""); want != got {
+	if want, got := "/1010/templates/1/records", templateRecordPath("1010", "1", 0); want != got {
 		t.Errorf("templateRecordPath(%v, %v, ) = %v, want %v", "1010", "1", got, want)
 	}
 
-	if want, got := "/1010/templates/1/records/2", templateRecordPath("1010", "1", "2"); want != got {
+	if want, got := "/1010/templates/1/records/2", templateRecordPath("1010", "1", 2); want != got {
 		t.Errorf("templateRecordPath(%v, %v, 2) = %v, want %v", "1010", "1", got, want)
 	}
 }
@@ -121,7 +121,7 @@ func TestTemplatesService_GetTemplateRecord(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	templateRecordResponse, err := client.Templates.GetTemplateRecord("1010", "1", "2")
+	templateRecordResponse, err := client.Templates.GetTemplateRecord("1010", "1", 2)
 	if err != nil {
 		t.Fatalf("Templates.GetTemplateRecord() returned error: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestTemplatesService_DeleteTemplateRecord(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Templates.DeleteTemplateRecord("1010", "1", "2")
+	_, err := client.Templates.DeleteTemplateRecord("1010", "1", 2)
 	if err != nil {
 		t.Fatalf("Templates.DeleteTemplateRecord() returned error: %v", err)
 	}

--- a/dnsimple/templates_test.go
+++ b/dnsimple/templates_test.go
@@ -47,7 +47,7 @@ func TestTemplatesService_List(t *testing.T) {
 		t.Errorf("Templates.ListTemplates() expected to return %v templates, got %v", want, got)
 	}
 
-	if want, got := 1, templates[0].ID; want != got {
+	if want, got := int64(1), templates[0].ID; want != got {
 		t.Fatalf("Templates.ListTemplates() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "Alpha", templates[0].Name; want != got {
@@ -100,7 +100,7 @@ func TestTemplatesService_Create(t *testing.T) {
 	}
 
 	template := templateResponse.Data
-	if want, got := 1, template.ID; want != got {
+	if want, got := int64(1), template.ID; want != got {
 		t.Fatalf("Templates.CreateTemplate() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "Beta", template.Name; want != got {

--- a/dnsimple/users.go
+++ b/dnsimple/users.go
@@ -2,6 +2,6 @@ package dnsimple
 
 // User represents a DNSimple user.
 type User struct {
-	ID    int    `json:"id,omitempty"`
+	ID    int64  `json:"id,omitempty"`
 	Email string `json:"email,omitempty"`
 }

--- a/dnsimple/vanity_name_server.go
+++ b/dnsimple/vanity_name_server.go
@@ -14,7 +14,7 @@ type VanityNameServersService struct {
 
 // VanityNameServer represents data for a single vanity name server
 type VanityNameServer struct {
-	ID        int    `json:"id,omitempty"`
+	ID        int64  `json:"id,omitempty"`
 	Name      string `json:"name,omitempty"`
 	IPv4      string `json:"ipv4,omitempty"`
 	IPv6      string `json:"ipv6,omitempty"`
@@ -22,8 +22,8 @@ type VanityNameServer struct {
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-func vanityNameServerPath(accountID string, domainID string) string {
-	return fmt.Sprintf("/%v/vanity/%v", accountID, domainID)
+func vanityNameServerPath(accountID string, domainIdentifier string) string {
+	return fmt.Sprintf("/%v/vanity/%v", accountID, domainIdentifier)
 }
 
 // vanityNameServerResponse represents a response for vanity name server enable and disable operations.
@@ -35,8 +35,8 @@ type vanityNameServerResponse struct {
 // EnableVanityNameServers Vanity Name Servers for the given domain
 //
 // See https://developer.dnsimple.com/v2/vanity/#enable
-func (s *VanityNameServersService) EnableVanityNameServers(accountID string, domainID string) (*vanityNameServerResponse, error) {
-	path := versioned(vanityNameServerPath(accountID, domainID))
+func (s *VanityNameServersService) EnableVanityNameServers(accountID string, domainIdentifier string) (*vanityNameServerResponse, error) {
+	path := versioned(vanityNameServerPath(accountID, domainIdentifier))
 	vanityNameServerResponse := &vanityNameServerResponse{}
 
 	resp, err := s.client.put(path, nil, vanityNameServerResponse)
@@ -51,8 +51,8 @@ func (s *VanityNameServersService) EnableVanityNameServers(accountID string, dom
 // DisableVanityNameServers Vanity Name Servers for the given domain
 //
 // See https://developer.dnsimple.com/v2/vanity/#disable
-func (s *VanityNameServersService) DisableVanityNameServers(accountID string, domainID string) (*vanityNameServerResponse, error) {
-	path := versioned(vanityNameServerPath(accountID, domainID))
+func (s *VanityNameServersService) DisableVanityNameServers(accountID string, domainIdentifier string) (*vanityNameServerResponse, error) {
+	path := versioned(vanityNameServerPath(accountID, domainIdentifier))
 	vanityNameServerResponse := &vanityNameServerResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)

--- a/dnsimple/webhook/events_test.go
+++ b/dnsimple/webhook/events_test.go
@@ -571,7 +571,7 @@ func TestParseWhoisPrivacyEvent_WhoisPrivacy_Disable(t *testing.T) {
 	if want, got := "example.com", event.Domain.Name; want != got {
 		t.Errorf("ParseEvent Domain.Name expected to be %v, got %v", want, got)
 	}
-	if want, got := 3, event.WhoisPrivacy.ID; want != got {
+	if want, got := int64(3), event.WhoisPrivacy.ID; want != got {
 		t.Errorf("ParseEvent WhoisPrivacy.ID expected to be %v, got %v", want, got)
 	}
 
@@ -600,7 +600,7 @@ func TestParseWhoisPrivacyEvent_WhoisPrivacy_Enable(t *testing.T) {
 	if want, got := "example.com", event.Domain.Name; want != got {
 		t.Errorf("ParseEvent Domain.Name expected to be %v, got %v", want, got)
 	}
-	if want, got := 3, event.WhoisPrivacy.ID; want != got {
+	if want, got := int64(3), event.WhoisPrivacy.ID; want != got {
 		t.Errorf("ParseEvent WhoisPrivacy.ID expected to be %v, got %v", want, got)
 	}
 
@@ -629,7 +629,7 @@ func TestParseWhoisPrivacyEvent_WhoisPrivacy_Purchase(t *testing.T) {
 	if want, got := "example.com", event.Domain.Name; want != got {
 		t.Errorf("ParseEvent Domain.Name expected to be %v, got %v", want, got)
 	}
-	if want, got := 3, event.WhoisPrivacy.ID; want != got {
+	if want, got := int64(3), event.WhoisPrivacy.ID; want != got {
 		t.Errorf("ParseEvent WhoisPrivacy.ID expected to be %v, got %v", want, got)
 	}
 
@@ -658,7 +658,7 @@ func TestParseWhoisPrivacyEvent_WhoisPrivacy_Renew(t *testing.T) {
 	if want, got := "example.com", event.Domain.Name; want != got {
 		t.Errorf("ParseEvent Domain.Name expected to be %v, got %v", want, got)
 	}
-	if want, got := 3, event.WhoisPrivacy.ID; want != got {
+	if want, got := int64(3), event.WhoisPrivacy.ID; want != got {
 		t.Errorf("ParseEvent WhoisPrivacy.ID expected to be %v, got %v", want, got)
 	}
 

--- a/dnsimple/webhooks.go
+++ b/dnsimple/webhooks.go
@@ -14,11 +14,11 @@ type WebhooksService struct {
 
 // Webhook represents a DNSimple webhook.
 type Webhook struct {
-	ID  int    `json:"id,omitempty"`
+	ID  int64    `json:"id,omitempty"`
 	URL string `json:"url,omitempty"`
 }
 
-func webhookPath(accountID string, webhookID int) (path string) {
+func webhookPath(accountID string, webhookID int64) (path string) {
 	path = fmt.Sprintf("/%v/webhooks", accountID)
 	if webhookID != 0 {
 		path = fmt.Sprintf("%v/%v", path, webhookID)
@@ -73,7 +73,7 @@ func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webh
 // GetWebhook fetches a webhook.
 //
 // See https://developer.dnsimple.com/v2/webhooks#get
-func (s *WebhooksService) GetWebhook(accountID string, webhookID int) (*webhookResponse, error) {
+func (s *WebhooksService) GetWebhook(accountID string, webhookID int64) (*webhookResponse, error) {
 	path := versioned(webhookPath(accountID, webhookID))
 	webhookResponse := &webhookResponse{}
 
@@ -89,7 +89,7 @@ func (s *WebhooksService) GetWebhook(accountID string, webhookID int) (*webhookR
 // DeleteWebhook PERMANENTLY deletes a webhook from the account.
 //
 // See https://developer.dnsimple.com/v2/webhooks#delete
-func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int) (*webhookResponse, error) {
+func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int64) (*webhookResponse, error) {
 	path := versioned(webhookPath(accountID, webhookID))
 	webhookResponse := &webhookResponse{}
 

--- a/dnsimple/webhooks_test.go
+++ b/dnsimple/webhooks_test.go
@@ -41,7 +41,7 @@ func TestWebhooksService_ListWebhooks(t *testing.T) {
 		t.Errorf("Webhooks.List() expected to return %v webhooks, got %v", want, got)
 	}
 
-	if want, got := 1, webhooks[0].ID; want != got {
+	if want, got := int64(1), webhooks[0].ID; want != got {
 		t.Fatalf("Webhooks.List() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "https://webhook.test", webhooks[0].URL; want != got {
@@ -74,7 +74,7 @@ func TestWebhooksService_CreateWebhook(t *testing.T) {
 	}
 
 	webhook := webhookResponse.Data
-	if want, got := 1, webhook.ID; want != got {
+	if want, got := int64(1), webhook.ID; want != got {
 		t.Fatalf("Webhooks.Create() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "https://webhook.test", webhook.URL; want != got {

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -14,8 +14,8 @@ type ZonesService struct {
 
 // Zone represents a Zone in DNSimple.
 type Zone struct {
-	ID        int    `json:"id,omitempty"`
-	AccountID int    `json:"account_id,omitempty"`
+	ID        int64    `json:"id,omitempty"`
+	AccountID int64    `json:"account_id,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Reverse   bool   `json:"reverse,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -20,8 +20,8 @@ type ZoneRecord struct {
 	UpdatedAt    string   `json:"updated_at,omitempty"`
 }
 
-func zoneRecordPath(accountID string, zoneID string, recordID int) (path string) {
-	path = fmt.Sprintf("/%v/zones/%v/records", accountID, zoneID)
+func zoneRecordPath(accountID string, zoneName string, recordID int) (path string) {
+	path = fmt.Sprintf("/%v/zones/%v/records", accountID, zoneName)
 	if recordID != 0 {
 		path += fmt.Sprintf("/%d", recordID)
 	}
@@ -59,8 +59,8 @@ type ZoneRecordListOptions struct {
 // ListRecords lists the zone records for a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#list
-func (s *ZonesService) ListRecords(accountID string, zoneID string, options *ZoneRecordListOptions) (*zoneRecordsResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, 0))
+func (s *ZonesService) ListRecords(accountID string, zoneName string, options *ZoneRecordListOptions) (*zoneRecordsResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, 0))
 	recordsResponse := &zoneRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
@@ -80,8 +80,8 @@ func (s *ZonesService) ListRecords(accountID string, zoneID string, options *Zon
 // CreateRecord creates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#create
-func (s *ZonesService) CreateRecord(accountID string, zoneID string, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, 0))
+func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, 0))
 	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.post(path, recordAttributes, recordResponse)
@@ -96,8 +96,8 @@ func (s *ZonesService) CreateRecord(accountID string, zoneID string, recordAttri
 // GetRecord fetches a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#get
-func (s *ZonesService) GetRecord(accountID string, zoneID string, recordID int) (*zoneRecordResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.get(path, recordResponse)
@@ -112,8 +112,8 @@ func (s *ZonesService) GetRecord(accountID string, zoneID string, recordID int) 
 // UpdateRecord updates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#update
-func (s *ZonesService) UpdateRecord(accountID string, zoneID string, recordID int, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID int, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 	resp, err := s.client.patch(path, recordAttributes, recordResponse)
 
@@ -128,8 +128,8 @@ func (s *ZonesService) UpdateRecord(accountID string, zoneID string, recordID in
 // DeleteRecord PERMANENTLY deletes a zone record from the zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#delete
-func (s *ZonesService) DeleteRecord(accountID string, zoneID string, recordID int) (*zoneRecordResponse, error) {
-	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+func (s *ZonesService) DeleteRecord(accountID string, zoneName string, recordID int) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -6,9 +6,9 @@ import (
 
 // ZoneRecord represents a DNS record in DNSimple.
 type ZoneRecord struct {
-	ID           int      `json:"id,omitempty"`
+	ID           int64      `json:"id,omitempty"`
 	ZoneID       string   `json:"zone_id,omitempty"`
-	ParentID     int      `json:"parent_id,omitempty"`
+	ParentID     int64      `json:"parent_id,omitempty"`
 	Type         string   `json:"type,omitempty"`
 	Name         string   `json:"name"`
 	Content      string   `json:"content,omitempty"`
@@ -20,10 +20,10 @@ type ZoneRecord struct {
 	UpdatedAt    string   `json:"updated_at,omitempty"`
 }
 
-func zoneRecordPath(accountID string, zoneName string, recordID int) (path string) {
+func zoneRecordPath(accountID string, zoneName string, recordID int64) (path string) {
 	path = fmt.Sprintf("/%v/zones/%v/records", accountID, zoneName)
 	if recordID != 0 {
-		path += fmt.Sprintf("/%d", recordID)
+		path += fmt.Sprintf("/%v", recordID)
 	}
 	return
 }
@@ -96,7 +96,7 @@ func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAtt
 // GetRecord fetches a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#get
-func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int) (*zoneRecordResponse, error) {
+func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int64) (*zoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 
@@ -112,7 +112,7 @@ func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int
 // UpdateRecord updates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/#update
-func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID int, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID int64, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 	resp, err := s.client.patch(path, recordAttributes, recordResponse)
@@ -128,7 +128,7 @@ func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID 
 // DeleteRecord PERMANENTLY deletes a zone record from the zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#delete
-func (s *ZonesService) DeleteRecord(accountID string, zoneName string, recordID int) (*zoneRecordResponse, error) {
+func (s *ZonesService) DeleteRecord(accountID string, zoneName string, recordID int64) (*zoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 

--- a/dnsimple/zones_records_test.go
+++ b/dnsimple/zones_records_test.go
@@ -46,7 +46,7 @@ func TestZonesService_ListRecords(t *testing.T) {
 		t.Errorf("Zones.ListRecords() expected to return %v contacts, got %v", want, got)
 	}
 
-	if want, got := 1, records[0].ID; want != got {
+	if want, got := int64(1), records[0].ID; want != got {
 		t.Fatalf("Zones.ListRecords() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "", records[0].Name; want != got {
@@ -109,7 +109,7 @@ func TestZonesService_CreateRecord(t *testing.T) {
 	}
 
 	record := recordResponse.Data
-	if want, got := 1, record.ID; want != got {
+	if want, got := int64(1), record.ID; want != got {
 		t.Fatalf("Zones.CreateRecord() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "www", record.Name; want != got {
@@ -275,7 +275,7 @@ func TestZonesService_UpdateRecord(t *testing.T) {
 	}
 
 	record := recordResponse.Data
-	if want, got := 5, record.ID; want != got {
+	if want, got := int64(5), record.ID; want != got {
 		t.Fatalf("Zones.UpdateRecord() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "mxb.example.com", record.Content; want != got {

--- a/dnsimple/zones_test.go
+++ b/dnsimple/zones_test.go
@@ -36,7 +36,7 @@ func TestZonesService_ListZones(t *testing.T) {
 		t.Errorf("Zones.ListZones() expected to return %v zones, got %v", want, got)
 	}
 
-	if want, got := 1, zones[0].ID; want != got {
+	if want, got := int64(1), zones[0].ID; want != got {
 		t.Fatalf("Zones.ListZones() returned ID expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "example-alpha.com", zones[0].Name; want != got {


### PR DESCRIPTION
int corresponds to int32 on 32-bit systems, causing incompatibilities when IDs are beyond 32 size (mostly records).

As a convention, getting inspiration from other libraries, I've upgraded all identifiers to int64.