### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -62,7 +62,7 @@ type DomainPremiumPriceOptions struct {
 	Action string `url:"action,omitempty"`
 }
 
-// Gets the premium price for a domain.
+// GetDomainPremiumPrice gets the premium price for a domain.
 //
 // You must specify an action to get the price for. Valid actions are:
 // - registration

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -70,7 +70,7 @@ func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName strin
 	return privacyResponse, nil
 }
 
-// DisablePrivacy disables the whois privacy for the domain.
+// DisableWhoisPrivacy disables the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
 func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -100,7 +100,7 @@ func (s *TldsService) GetTld(tld string) (*tldResponse, error) {
 	return tldResponse, nil
 }
 
-// GetTld fetches the extended attributes of a TLD.
+// GetTldExtendedAttributes fetches the extended attributes of a TLD.
 //
 // See https://developer.dnsimple.com/v2/tlds/#get
 func (s *TldsService) GetTldExtendedAttributes(tld string) (*tldExtendedAttributesResponse, error) {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?