### PR TITLE
Adding Extended Attributes to register and transfer domain

### DIFF
--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -121,6 +121,8 @@ type DomainRegisterRequest struct {
 	// Set to true to enable the auto-renewal of the domain.
 	// Default to true.
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
+	// Required by some TLD's, use Tlds.GetTldExtendedAttributes to get the required entries
+	ExtendedAttributes map[string]string `json:"extended_attributes,omitempty"`
 	// Required as confirmation of the price, only if the domain is premium.
 	PremiumPrice string `json:"premium_price,omitempty"`
 }

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -177,6 +177,8 @@ type DomainTransferRequest struct {
 	// Set to true to enable the auto-renewal of the domain.
 	// Default to true.
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
+	// Required by some TLD's, use Tlds.GetTldExtendedAttributes to get the required entries
+	ExtendedAttributes map[string]string `json:"extended_attributes,omitempty"`
 	// Required as confirmation of the price, only if the domain is premium.
 	PremiumPrice string `json:"premium_price,omitempty"`
 }


### PR DESCRIPTION
The extended attributes field is required for several TLD's around the world, I hope it'll be useful to other developers outside the US who do deal with extended attribute domains semi frequently.