### PR TITLE
Change format of User-Agent

### DIFF
--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -146,7 +146,7 @@ func formatUserAgent(customUserAgent string) string {
 		return defaultUserAgent
 	}
 
-	return fmt.Sprintf("%s %s", defaultUserAgent, customUserAgent)
+	return fmt.Sprintf("%s %s", customUserAgent, defaultUserAgent)
 }
 
 func versioned(path string) string {

--- a/dnsimple/dnsimple_test.go
+++ b/dnsimple/dnsimple_test.go
@@ -143,7 +143,7 @@ func TestClient_NewRequest_CustomUserAgent(t *testing.T) {
 
 	// test that default user-agent is attached to the request
 	ua := req.Header.Get("User-Agent")
-	if want := fmt.Sprintf("%s AwesomeClient", defaultUserAgent); ua != want {
+	if want := fmt.Sprintf("AwesomeClient %s", defaultUserAgent); ua != want {
 		t.Errorf("NewRequest() User-Agent = %v, want %v", ua, want)
 	}
 }


### PR DESCRIPTION
If a custom user agent string is specified, the final user agent is composed by:

```
default CUSTOM
``` 

I propose to change the format to

```
CUSTOM default
```

It makes more sense to me as the CUSTOM string can be arbitrary complex and it's actually the primary reference.

This will facilitate the bundling of the client in larger projects. See for instance the proposed user agent standardization in Terraform Plugin SDK: [`httpclient.TerraformUserAgent`](https://github.com/hashicorp/terraform-plugin-sdk/blob/e664f5b78081fde148c4ea55a0e068dc62fb2274/httpclient/useragent.go#L14)

See https://github.com/terraform-providers/terraform-provider-dnsimple/pull/24 for details. The current user agent will be

```
dnsimple-go/v0.30.0 HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s
```

whereas it would make more sense as

```
HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s dnsimple-go/v0.30.0
```