### PR TITLE
Introduce request contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - NEW: Added Client.SetUserAgent() as a convenient helper to set a custom user agent.
 - NEW: Added support for Registration/Transfer extended attributes (dnsimple/dnsimple-go#86)
 
+Incompatible changes:
+
+- NEW: Added support for context (dnsimple/dnsimple-go#82, dnsimple/dnsimple-go#90)
+
+- CHANGED: Changed all method signatures so that the returned value is exported (dnsimple/dnsimple-go#91)
+
+
 
 #### Release 0.40.0
 
@@ -12,7 +19,6 @@ Incompatible changes:
 
 - CHANGED: Renamed ExchangeAuthorizationError.HttpResponse field to ExchangeAuthorizationError.HTTPResponse
 - CHANGED: Renamed Response.HttpResponse field to Response.HTTPResponse
-- CHANGED: Changed all method signatures so that the returned value is exported (dnsimple/dnsimple-go#91)
 
 - REMOVED: Deleted deprecated ResetDomainToken method.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Incompatible changes:
 - CHANGED: Changed all method signatures so that the returned value is exported (dnsimple/dnsimple-go#91)
 
 
-
 #### Release 0.40.0
 
 Incompatible changes:

--- a/dnsimple/accounts.go
+++ b/dnsimple/accounts.go
@@ -1,5 +1,9 @@
 package dnsimple
 
+import (
+	"context"
+)
+
 // AccountsService handles communication with the account related
 // methods of the DNSimple API.
 //
@@ -35,7 +39,7 @@ func (s *AccountsService) ListAccounts(options *ListOptions) (*accountsResponse,
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, accountsResponse)
+	resp, err := s.client.get(context.TODO(), path, accountsResponse)
 	if err != nil {
 		return accountsResponse, err
 	}

--- a/dnsimple/accounts.go
+++ b/dnsimple/accounts.go
@@ -30,7 +30,7 @@ type AccountsResponse struct {
 // ListAccounts list the accounts for an user.
 //
 // See https://developer.dnsimple.com/v2/accounts/#list
-func (s *AccountsService) ListAccounts(options *ListOptions) (*AccountsResponse, error) {
+func (s *AccountsService) ListAccounts(ctx context.Context, options *ListOptions) (*AccountsResponse, error) {
 	path := versioned("/accounts")
 	accountsResponse := &AccountsResponse{}
 
@@ -39,7 +39,7 @@ func (s *AccountsService) ListAccounts(options *ListOptions) (*AccountsResponse,
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, accountsResponse)
+	resp, err := s.client.get(ctx, path, accountsResponse)
 	if err != nil {
 		return accountsResponse, err
 	}

--- a/dnsimple/accounts_test.go
+++ b/dnsimple/accounts_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,7 +23,7 @@ func TestAccountsService_List(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	accountsResponse, err := client.Accounts.ListAccounts(nil)
+	accountsResponse, err := client.Accounts.ListAccounts(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Accounts.ListAccounts() returned error: %v", err)
 	}

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -127,7 +127,7 @@ func (s *CertificatesService) ListCertificates(accountID, domainIdentifier strin
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, certificatesResponse)
+	resp, err := s.client.get(context.TODO(), path, certificatesResponse)
 	if err != nil {
 		return certificatesResponse, err
 	}
@@ -143,7 +143,7 @@ func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string,
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID))
 	certificateResponse := &certificateResponse{}
 
-	resp, err := s.client.get(path, certificateResponse)
+	resp, err := s.client.get(context.TODO(), path, certificateResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier st
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID) + "/download")
 	certificateBundleResponse := &certificateBundleResponse{}
 
-	resp, err := s.client.get(path, certificateBundleResponse)
+	resp, err := s.client.get(context.TODO(), path, certificateBundleResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifi
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID) + "/private_key")
 	certificateBundleResponse := &certificateBundleResponse{}
 
-	resp, err := s.client.get(path, certificateBundleResponse)
+	resp, err := s.client.get(context.TODO(), path, certificateBundleResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -118,7 +118,7 @@ type CertificateRenewalResponse struct {
 // ListCertificates lists the certificates for a domain in the account.
 //
 // See https://developer.dnsimple.com/v2/certificates#listCertificates
-func (s *CertificatesService) ListCertificates(accountID, domainIdentifier string, options *ListOptions) (*CertificatesResponse, error) {
+func (s *CertificatesService) ListCertificates(ctx context.Context, accountID, domainIdentifier string, options *ListOptions) (*CertificatesResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, 0))
 	certificatesResponse := &CertificatesResponse{}
 
@@ -127,7 +127,7 @@ func (s *CertificatesService) ListCertificates(accountID, domainIdentifier strin
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, certificatesResponse)
+	resp, err := s.client.get(ctx, path, certificatesResponse)
 	if err != nil {
 		return certificatesResponse, err
 	}
@@ -139,11 +139,11 @@ func (s *CertificatesService) ListCertificates(accountID, domainIdentifier strin
 // GetCertificate gets the details of a certificate.
 //
 // See https://developer.dnsimple.com/v2/certificates#getCertificate
-func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string, certificateID int64) (*CertificateResponse, error) {
+func (s *CertificatesService) GetCertificate(ctx context.Context, accountID, domainIdentifier string, certificateID int64) (*CertificateResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID))
 	certificateResponse := &CertificateResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, certificateResponse)
+	resp, err := s.client.get(ctx, path, certificateResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -156,11 +156,11 @@ func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string,
 // along with the root certificate and intermediate chain.
 //
 // See https://developer.dnsimple.com/v2/certificates#downloadCertificate
-func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier string, certificateID int64) (*CertificateBundleResponse, error) {
+func (s *CertificatesService) DownloadCertificate(ctx context.Context, accountID, domainIdentifier string, certificateID int64) (*CertificateBundleResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID) + "/download")
 	certificateBundleResponse := &CertificateBundleResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, certificateBundleResponse)
+	resp, err := s.client.get(ctx, path, certificateBundleResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -172,11 +172,11 @@ func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier st
 // GetCertificatePrivateKey gets the PEM-encoded certificate private key.
 //
 // See https://developer.dnsimple.com/v2/certificates#getCertificatePrivateKey
-func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifier string, certificateID int64) (*CertificateBundleResponse, error) {
+func (s *CertificatesService) GetCertificatePrivateKey(ctx context.Context, accountID, domainIdentifier string, certificateID int64) (*CertificateBundleResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID) + "/private_key")
 	certificateBundleResponse := &CertificateBundleResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, certificateBundleResponse)
+	resp, err := s.client.get(ctx, path, certificateBundleResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -188,11 +188,11 @@ func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifi
 // PurchaseLetsencryptCertificate purchases a Let's Encrypt certificate.
 //
 // See https://developer.dnsimple.com/v2/certificates/#purchaseLetsencryptCertificate
-func (s *CertificatesService) PurchaseLetsencryptCertificate(accountID, domainIdentifier string, certificateAttributes LetsencryptCertificateAttributes) (*CertificatePurchaseResponse, error) {
+func (s *CertificatesService) PurchaseLetsencryptCertificate(ctx context.Context, accountID, domainIdentifier string, certificateAttributes LetsencryptCertificateAttributes) (*CertificatePurchaseResponse, error) {
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, 0))
 	certificatePurchaseResponse := &CertificatePurchaseResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, certificateAttributes, certificatePurchaseResponse)
+	resp, err := s.client.post(ctx, path, certificateAttributes, certificatePurchaseResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -204,11 +204,11 @@ func (s *CertificatesService) PurchaseLetsencryptCertificate(accountID, domainId
 // IssueLetsencryptCertificate issues a pending Let's Encrypt certificate purchase order.
 //
 // See https://developer.dnsimple.com/v2/certificates/#issueLetsencryptCertificate
-func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdentifier string, certificateID int64) (*CertificateResponse, error) {
+func (s *CertificatesService) IssueLetsencryptCertificate(ctx context.Context, accountID, domainIdentifier string, certificateID int64) (*CertificateResponse, error) {
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + "/issue")
 	certificateResponse := &CertificateResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, nil, certificateResponse)
+	resp, err := s.client.post(ctx, path, nil, certificateResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -220,11 +220,11 @@ func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdent
 // PurchaseLetsencryptCertificateRenewal purchases a Let's Encrypt certificate renewal.
 //
 // See https://developer.dnsimple.com/v2/certificates/#purchaseRenewalLetsencryptCertificate
-func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID int64, certificateAttributes LetsencryptCertificateAttributes) (*CertificateRenewalResponse, error) {
+func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(ctx context.Context, accountID, domainIdentifier string, certificateID int64, certificateAttributes LetsencryptCertificateAttributes) (*CertificateRenewalResponse, error) {
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + "/renewals")
 	certificateRenewalResponse := &CertificateRenewalResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, certificateAttributes, certificateRenewalResponse)
+	resp, err := s.client.post(ctx, path, certificateAttributes, certificateRenewalResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -236,11 +236,11 @@ func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, d
 // IssueLetsencryptCertificateRenewal issues a pending Let's Encrypt certificate renewal order.
 //
 // See https://developer.dnsimple.com/v2/certificates/#issueRenewalLetsencryptCertificate
-func (s *CertificatesService) IssueLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID, certificateRenewalID int64) (*CertificateResponse, error) {
+func (s *CertificatesService) IssueLetsencryptCertificateRenewal(ctx context.Context, accountID, domainIdentifier string, certificateID, certificateRenewalID int64) (*CertificateResponse, error) {
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + fmt.Sprintf("/renewals/%d/issue", certificateRenewalID))
 	certificateResponse := &CertificateResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, nil, certificateResponse)
+	resp, err := s.client.post(ctx, path, nil, certificateResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -191,7 +192,7 @@ func (s *CertificatesService) PurchaseLetsencryptCertificate(accountID, domainId
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, 0))
 	certificatePurchaseResponse := &certificatePurchaseResponse{}
 
-	resp, err := s.client.post(path, certificateAttributes, certificatePurchaseResponse)
+	resp, err := s.client.post(context.TODO(), path, certificateAttributes, certificatePurchaseResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +208,7 @@ func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdent
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + "/issue")
 	certificateResponse := &certificateResponse{}
 
-	resp, err := s.client.post(path, nil, certificateResponse)
+	resp, err := s.client.post(context.TODO(), path, nil, certificateResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +224,7 @@ func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, d
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + "/renewals")
 	certificateRenewalResponse := &certificateRenewalResponse{}
 
-	resp, err := s.client.post(path, certificateAttributes, certificateRenewalResponse)
+	resp, err := s.client.post(context.TODO(), path, certificateAttributes, certificateRenewalResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +240,7 @@ func (s *CertificatesService) IssueLetsencryptCertificateRenewal(accountID, doma
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + fmt.Sprintf("/renewals/%d/issue", certificateRenewalID))
 	certificateResponse := &certificateResponse{}
 
-	resp, err := s.client.post(path, nil, certificateResponse)
+	resp, err := s.client.post(context.TODO(), path, nil, certificateResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/certificates_test.go
+++ b/dnsimple/certificates_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -32,7 +33,7 @@ func TestCertificatesService_ListCertificates(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	certificatesResponse, err := client.Certificates.ListCertificates("1010", "example.com", nil)
+	certificatesResponse, err := client.Certificates.ListCertificates(context.Background(), "1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("Certificates.ListCertificates() returned error: %v", err)
 	}
@@ -67,7 +68,7 @@ func TestCertificatesService_ListCertificates_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Certificates.ListCertificates("1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Certificates.ListCertificates(context.Background(), "1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Certificates.ListCertificates() returned error: %v", err)
 	}
@@ -87,7 +88,7 @@ func TestCertificatesService_GetCertificate(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	certificateResponse, err := client.Certificates.GetCertificate("1010", "example.com", 2)
+	certificateResponse, err := client.Certificates.GetCertificate(context.Background(), "1010", "example.com", 2)
 	if err != nil {
 		t.Errorf("Certificates.GetCertificate() returned error: %v", err)
 	}
@@ -128,7 +129,7 @@ func TestCertificatesService_DownloadCertificate(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	certificateBundleResponse, err := client.Certificates.DownloadCertificate("1010", "example.com", 2)
+	certificateBundleResponse, err := client.Certificates.DownloadCertificate(context.Background(), "1010", "example.com", 2)
 	if err != nil {
 		t.Errorf("Certificates.DownloadCertificate() returned error: %v", err)
 	}
@@ -161,7 +162,7 @@ func TestCertificatesService_GetCertificatePrivateKey(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	certificateBundleResponse, err := client.Certificates.GetCertificatePrivateKey("1010", "example.com", 2)
+	certificateBundleResponse, err := client.Certificates.GetCertificatePrivateKey(context.Background(), "1010", "example.com", 2)
 	if err != nil {
 		t.Errorf("Certificates.GetCertificatePrivateKey() returned error: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestCertificates_LetsencryptPurchase(t *testing.T) {
 
 	certificateAttributes := LetsencryptCertificateAttributes{ContactID: 100}
 
-	certificateResponse, err := client.Certificates.PurchaseLetsencryptCertificate("1010", "example.com", certificateAttributes)
+	certificateResponse, err := client.Certificates.PurchaseLetsencryptCertificate(context.Background(), "1010", "example.com", certificateAttributes)
 	if err != nil {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificate() returned error: %v", err)
 	}
@@ -224,7 +225,7 @@ func TestCertificates_LetsencryptPurchaseWithAttributes(t *testing.T) {
 
 	certificateAttributes := LetsencryptCertificateAttributes{ContactID: 100, Name: "www", AutoRenew: true, AlternateNames: []string{"api.example.com", "status.example.com"}}
 
-	_, err := client.Certificates.PurchaseLetsencryptCertificate("1010", "example.com", certificateAttributes)
+	_, err := client.Certificates.PurchaseLetsencryptCertificate(context.Background(), "1010", "example.com", certificateAttributes)
 	if err != nil {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificate() returned error: %v", err)
 	}
@@ -244,7 +245,7 @@ func TestCertificates_LetsencryptIssue(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	certificateResponse, err := client.Certificates.IssueLetsencryptCertificate("1010", "example.com", 200)
+	certificateResponse, err := client.Certificates.IssueLetsencryptCertificate(context.Background(), "1010", "example.com", 200)
 	if err != nil {
 		t.Fatalf("Certificates.IssueLetsencryptCertificate() returned error: %v", err)
 	}
@@ -274,7 +275,7 @@ func TestCertificates_LetsencryptPurchaseRenewal(t *testing.T) {
 
 	certificateAttributes := LetsencryptCertificateAttributes{}
 
-	certificateRenewalResponse, err := client.Certificates.PurchaseLetsencryptCertificateRenewal("1010", "example.com", 200, certificateAttributes)
+	certificateRenewalResponse, err := client.Certificates.PurchaseLetsencryptCertificateRenewal(context.Background(), "1010", "example.com", 200, certificateAttributes)
 	if err != nil {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificateRenewal() returned error: %v", err)
 	}
@@ -313,7 +314,7 @@ func TestCertificates_LetsencryptPurchaseRenewalWithAttributes(t *testing.T) {
 
 	certificateAttributes := LetsencryptCertificateAttributes{AutoRenew: true}
 
-	certificateRenewalResponse, err := client.Certificates.PurchaseLetsencryptCertificateRenewal("1010", "example.com", 200, certificateAttributes)
+	certificateRenewalResponse, err := client.Certificates.PurchaseLetsencryptCertificateRenewal(context.Background(), "1010", "example.com", 200, certificateAttributes)
 	if err != nil {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificateRenewal() returned error: %v", err)
 	}
@@ -347,7 +348,7 @@ func TestCertificates_LetsencryptIssueRenewal(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	certificateResponse, err := client.Certificates.IssueLetsencryptCertificateRenewal("1010", "example.com", 200, 999)
+	certificateResponse, err := client.Certificates.IssueLetsencryptCertificateRenewal(context.Background(), "1010", "example.com", 200, 999)
 	if err != nil {
 		t.Fatalf("Certificates.IssueLetsencryptCertificateRenewal() returned error: %v", err)
 	}

--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -67,7 +67,7 @@ func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, contactsResponse)
+	resp, err := s.client.get(context.TODO(), path, contactsResponse)
 	if err != nil {
 		return contactsResponse, err
 	}
@@ -99,7 +99,7 @@ func (s *ContactsService) GetContact(accountID string, contactID int64) (*contac
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &contactResponse{}
 
-	resp, err := s.client.get(path, contactResponse)
+	resp, err := s.client.get(context.TODO(), path, contactResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -58,7 +58,7 @@ type ContactsResponse struct {
 // ListContacts list the contacts for an account.
 //
 // See https://developer.dnsimple.com/v2/contacts/#list
-func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (*ContactsResponse, error) {
+func (s *ContactsService) ListContacts(ctx context.Context, accountID string, options *ListOptions) (*ContactsResponse, error) {
 	path := versioned(contactPath(accountID, 0))
 	contactsResponse := &ContactsResponse{}
 
@@ -67,7 +67,7 @@ func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, contactsResponse)
+	resp, err := s.client.get(ctx, path, contactsResponse)
 	if err != nil {
 		return contactsResponse, err
 	}
@@ -79,11 +79,11 @@ func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (
 // CreateContact creates a new contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#create
-func (s *ContactsService) CreateContact(accountID string, contactAttributes Contact) (*ContactResponse, error) {
+func (s *ContactsService) CreateContact(ctx context.Context, accountID string, contactAttributes Contact) (*ContactResponse, error) {
 	path := versioned(contactPath(accountID, 0))
 	contactResponse := &ContactResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, contactAttributes, contactResponse)
+	resp, err := s.client.post(ctx, path, contactAttributes, contactResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -95,11 +95,11 @@ func (s *ContactsService) CreateContact(accountID string, contactAttributes Cont
 // GetContact fetches a contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#get
-func (s *ContactsService) GetContact(accountID string, contactID int64) (*ContactResponse, error) {
+func (s *ContactsService) GetContact(ctx context.Context, accountID string, contactID int64) (*ContactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &ContactResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, contactResponse)
+	resp, err := s.client.get(ctx, path, contactResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -111,11 +111,11 @@ func (s *ContactsService) GetContact(accountID string, contactID int64) (*Contac
 // UpdateContact updates a contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#update
-func (s *ContactsService) UpdateContact(accountID string, contactID int64, contactAttributes Contact) (*ContactResponse, error) {
+func (s *ContactsService) UpdateContact(ctx context.Context, accountID string, contactID int64, contactAttributes Contact) (*ContactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &ContactResponse{}
 
-	resp, err := s.client.patch(context.TODO(), path, contactAttributes, contactResponse)
+	resp, err := s.client.patch(ctx, path, contactAttributes, contactResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -127,11 +127,11 @@ func (s *ContactsService) UpdateContact(accountID string, contactID int64, conta
 // DeleteContact PERMANENTLY deletes a contact from the account.
 //
 // See https://developer.dnsimple.com/v2/contacts/#delete
-func (s *ContactsService) DeleteContact(accountID string, contactID int64) (*ContactResponse, error) {
+func (s *ContactsService) DeleteContact(ctx context.Context, accountID string, contactID int64) (*ContactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &ContactResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -115,7 +115,7 @@ func (s *ContactsService) UpdateContact(accountID string, contactID int64, conta
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &contactResponse{}
 
-	resp, err := s.client.patch(path, contactAttributes, contactResponse)
+	resp, err := s.client.patch(context.TODO(), path, contactAttributes, contactResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -130,7 +131,7 @@ func (s *ContactsService) DeleteContact(accountID string, contactID int64) (*con
 	path := versioned(contactPath(accountID, contactID))
 	contactResponse := &contactResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -83,7 +83,7 @@ func (s *ContactsService) CreateContact(accountID string, contactAttributes Cont
 	path := versioned(contactPath(accountID, 0))
 	contactResponse := &contactResponse{}
 
-	resp, err := s.client.post(path, contactAttributes, contactResponse)
+	resp, err := s.client.post(context.TODO(), path, contactAttributes, contactResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/contacts_test.go
+++ b/dnsimple/contacts_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func TestContactsService_List(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	contactsResponse, err := client.Contacts.ListContacts("1010", nil)
+	contactsResponse, err := client.Contacts.ListContacts(context.Background(), "1010", nil)
 	if err != nil {
 		t.Fatalf("Contacts.ListContacts() returned error: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestContactsService_List_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Contacts.ListContacts("1010", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Contacts.ListContacts(context.Background(), "1010", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Contacts.ListContacts() returned error: %v", err)
 	}
@@ -94,7 +95,7 @@ func TestContactsService_Create(t *testing.T) {
 	accountID := "1010"
 	contactAttributes := Contact{Label: "Default"}
 
-	contactResponse, err := client.Contacts.CreateContact(accountID, contactAttributes)
+	contactResponse, err := client.Contacts.CreateContact(context.Background(), accountID, contactAttributes)
 	if err != nil {
 		t.Fatalf("Contacts.CreateContact() returned error: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestContactsService_Get(t *testing.T) {
 	accountID := "1010"
 	contactID := int64(1)
 
-	contactResponse, err := client.Contacts.GetContact(accountID, contactID)
+	contactResponse, err := client.Contacts.GetContact(context.Background(), accountID, contactID)
 	if err != nil {
 		t.Fatalf("Contacts.GetContact() returned error: %v", err)
 	}
@@ -176,7 +177,7 @@ func TestContactsService_Update(t *testing.T) {
 	accountID := "1010"
 	contactID := int64(1)
 
-	contactResponse, err := client.Contacts.UpdateContact(accountID, contactID, contactAttributes)
+	contactResponse, err := client.Contacts.UpdateContact(context.Background(), accountID, contactID, contactAttributes)
 	if err != nil {
 		t.Fatalf("Contacts.UpdateContact() returned error: %v", err)
 	}
@@ -207,7 +208,7 @@ func TestContactsService_Delete(t *testing.T) {
 	accountID := "1010"
 	contactID := int64(1)
 
-	_, err := client.Contacts.DeleteContact(accountID, contactID)
+	_, err := client.Contacts.DeleteContact(context.Background(), accountID, contactID)
 	if err != nil {
 		t.Fatalf("Contacts.DeleteContact() returned error: %v", err)
 	}

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -144,8 +144,8 @@ func (c *Client) get(path string, obj interface{}) (*http.Response, error) {
 	return c.makeRequest(context.TODO(), http.MethodGet, path, nil, obj, nil)
 }
 
-func (c *Client) post(path string, payload, obj interface{}) (*http.Response, error) {
-	return c.makeRequest(context.TODO(), http.MethodPost, path, payload, obj, nil)
+func (c *Client) post(ctx context.Context, path string, payload, obj interface{}) (*http.Response, error) {
+	return c.makeRequest(ctx, http.MethodPost, path, payload, obj, nil)
 }
 
 func (c *Client) put(ctx context.Context, path string, payload, obj interface{}) (*http.Response, error) {

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -140,8 +140,8 @@ func versioned(path string) string {
 	return fmt.Sprintf("/%s/%s", apiVersion, strings.Trim(path, "/"))
 }
 
-func (c *Client) get(path string, obj interface{}) (*http.Response, error) {
-	return c.makeRequest(context.TODO(), http.MethodGet, path, nil, obj, nil)
+func (c *Client) get(ctx context.Context, path string, obj interface{}) (*http.Response, error) {
+	return c.makeRequest(ctx, http.MethodGet, path, nil, obj, nil)
 }
 
 func (c *Client) post(ctx context.Context, path string, payload, obj interface{}) (*http.Response, error) {

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -152,8 +152,8 @@ func (c *Client) put(path string, payload, obj interface{}) (*http.Response, err
 	return c.makeRequest(context.TODO(), http.MethodPut, path, payload, obj, nil)
 }
 
-func (c *Client) patch(path string, payload, obj interface{}) (*http.Response, error) {
-	return c.makeRequest(context.TODO(), http.MethodPatch, path, payload, obj, nil)
+func (c *Client) patch(ctx context.Context, path string, payload, obj interface{}) (*http.Response, error) {
+	return c.makeRequest(ctx, http.MethodPatch, path, payload, obj, nil)
 }
 
 func (c *Client) delete(ctx context.Context, path string, payload, obj interface{}) (*http.Response, error) {

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -156,8 +156,8 @@ func (c *Client) patch(path string, payload, obj interface{}) (*http.Response, e
 	return c.makeRequest(context.TODO(), http.MethodPatch, path, payload, obj, nil)
 }
 
-func (c *Client) delete(path string, payload, obj interface{}) (*http.Response, error) {
-	return c.makeRequest(context.TODO(), http.MethodDelete, path, payload, obj, nil)
+func (c *Client) delete(ctx context.Context, path string, payload, obj interface{}) (*http.Response, error) {
+	return c.makeRequest(ctx, http.MethodDelete, path, payload, obj, nil)
 }
 
 // Request executes an API request with the current client scope, and returns the response.

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -148,8 +148,8 @@ func (c *Client) post(path string, payload, obj interface{}) (*http.Response, er
 	return c.makeRequest(context.TODO(), http.MethodPost, path, payload, obj, nil)
 }
 
-func (c *Client) put(path string, payload, obj interface{}) (*http.Response, error) {
-	return c.makeRequest(context.TODO(), http.MethodPut, path, payload, obj, nil)
+func (c *Client) put(ctx context.Context, path string, payload, obj interface{}) (*http.Response, error) {
+	return c.makeRequest(ctx, http.MethodPut, path, payload, obj, nil)
 }
 
 func (c *Client) patch(ctx context.Context, path string, payload, obj interface{}) (*http.Response, error) {

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -4,7 +4,9 @@ package dnsimple
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -104,32 +106,6 @@ func NewClient(httpClient *http.Client) *Client {
 	return c
 }
 
-// NewRequest creates an API request.
-// The path is expected to be a relative path and will be resolved
-// according to the BaseURL of the Client. Paths should always be specified without a preceding slash.
-func (c *Client) NewRequest(method, path string, payload interface{}) (*http.Request, error) {
-	url := c.BaseURL + path
-
-	body := new(bytes.Buffer)
-	if payload != nil {
-		err := json.NewEncoder(body).Encode(payload)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	req, err := http.NewRequest(method, url, body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("User-Agent", formatUserAgent(c.UserAgent))
-
-	return req, nil
-}
-
 // SetUserAgent overrides the default UserAgent.
 //
 // When a custom user agent is provided, the final user agent is the combination of the custom user agent
@@ -165,70 +141,117 @@ func versioned(path string) string {
 }
 
 func (c *Client) get(path string, obj interface{}) (*http.Response, error) {
-	req, err := c.NewRequest("GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.Do(req, obj)
+	return c.makeRequest(context.TODO(), http.MethodGet, path, nil, obj, nil)
 }
 
 func (c *Client) post(path string, payload, obj interface{}) (*http.Response, error) {
-	req, err := c.NewRequest("POST", path, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.Do(req, obj)
+	return c.makeRequest(context.TODO(), http.MethodPost, path, payload, obj, nil)
 }
 
 func (c *Client) put(path string, payload, obj interface{}) (*http.Response, error) {
-	req, err := c.NewRequest("PUT", path, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.Do(req, obj)
+	return c.makeRequest(context.TODO(), http.MethodPut, path, payload, obj, nil)
 }
 
 func (c *Client) patch(path string, payload, obj interface{}) (*http.Response, error) {
-	req, err := c.NewRequest("PATCH", path, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.Do(req, obj)
+	return c.makeRequest(context.TODO(), http.MethodPatch, path, payload, obj, nil)
 }
 
-func (c *Client) delete(path string, payload interface{}, obj interface{}) (*http.Response, error) {
-	req, err := c.NewRequest("DELETE", path, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.Do(req, obj)
+func (c *Client) delete(path string, payload, obj interface{}) (*http.Response, error) {
+	return c.makeRequest(context.TODO(), http.MethodDelete, path, payload, obj, nil)
 }
 
-// Do sends an API request and returns the API response.
+// Request executes an API request with the current client scope, and returns the response.
+func (c *Client) Request(ctx context.Context, method, path string, payload, obj interface{}, headers http.Header) (*http.Response, error) {
+	return c.makeRequest(ctx, method, path, payload, obj, headers)
+}
+
+// makeRequest executes an API request and returns the HTTP response.
 //
-// The API response is JSON decoded and stored in the value pointed by obj,
+// The content pointed by payload is serialized and used as body of the request.
+// The HTTP response is JSON decoded and stored in the value pointed by obj.
+func (c *Client) makeRequest(ctx context.Context, method, path string, payload, obj interface{}, headers http.Header) (*http.Response, error) {
+	req, err := c.newRequestWithHeaders(method, path, payload, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Debug {
+		log.Printf("Request (%v): %#v", req.URL, req)
+	}
+
+	resp, err := c.request(ctx, req, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Debug {
+		log.Printf("Response: %#v", resp)
+	}
+
+	return resp, nil
+}
+
+// newRequest creates an API request.
+//
+// The path is expected to be a relative path and will be resolved according to the BaseURL of the Client.
+// Paths should always be specified without a preceding slash.
+func (c *Client) newRequest(method, path string, payload interface{}) (*http.Request, error) {
+	return c.newRequestWithHeaders(method, path, payload, nil)
+}
+
+// newRequestWithHeaders creates an API request, with custom headers.
+func (c *Client) newRequestWithHeaders(method, path string, payload interface{}, headers http.Header) (*http.Request, error) {
+	url := c.BaseURL + path
+
+	body := new(bytes.Buffer)
+	if payload != nil {
+		err := json.NewEncoder(body).Encode(payload)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	combinedHeaders := make(http.Header)
+	copyHeader(combinedHeaders, headers)
+	req.Header = combinedHeaders
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("User-Agent", formatUserAgent(c.UserAgent))
+
+	return req, err
+}
+
+// copyHeader copies all headers for `source` and sets them on `target`.
+// based on https://godoc.org/github.com/golang/gddo/httputil/header#Copy
+func copyHeader(target, source http.Header) {
+	for k, vs := range source {
+		target[k] = vs
+	}
+}
+
+// request sends the HTTP request and returns the HTTP response.
+//
+// The HTTP response is JSON decoded and stored in the value pointed by obj,
 // or returned as an error if an API error has occurred.
 // If obj implements the io.Writer interface, the raw response body will be written to obj,
 // without attempting to decode it.
-func (c *Client) Do(req *http.Request, obj interface{}) (*http.Response, error) {
-	if c.Debug {
-		log.Printf("Executing request (%v): %#v", req.URL, req)
+func (c *Client) request(ctx context.Context, req *http.Request, obj interface{}) (*http.Response, error) {
+	if ctx == nil {
+		return nil, errors.New("context must be non-nil")
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if c.Debug {
-		log.Printf("Response received: %#v", resp)
-	}
 
 	err = CheckResponse(resp)
 	if err != nil {

--- a/dnsimple/dnsimple_test.go
+++ b/dnsimple/dnsimple_test.go
@@ -136,7 +136,7 @@ func TestClient_SetUserAgent(t *testing.T) {
 		t.Errorf("UserAgent not assigned, expected %v, got %v", want, got)
 	}
 
-	req, _ := c.NewRequest("GET", "/foo", nil)
+	req, _ := c.newRequest("GET", "/foo", nil)
 
 	if want, got := "custom-agent/0.1 "+defaultUserAgent, req.Header.Get("User-Agent"); want != got {
 		t.Errorf("Incorrect User-Agent Header, expected %v, got %v", want, got)
@@ -148,7 +148,7 @@ func TestClient_NewRequest(t *testing.T) {
 	c.BaseURL = "https://go.example.com"
 
 	inURL, outURL := "/foo", "https://go.example.com/foo"
-	req, _ := c.NewRequest("GET", inURL, nil)
+	req, _ := c.newRequest("GET", inURL, nil)
 
 	// test that relative URL was expanded with the proper BaseURL
 	if req.URL.String() != outURL {
@@ -165,7 +165,7 @@ func TestClient_NewRequest(t *testing.T) {
 func TestClient_NewRequest_CustomUserAgent(t *testing.T) {
 	c := NewClient(http.DefaultClient)
 	c.UserAgent = "AwesomeClient"
-	req, _ := c.NewRequest("GET", "/", nil)
+	req, _ := c.newRequest("GET", "/", nil)
 
 	// test that default user-agent is attached to the request
 	ua := req.Header.Get("User-Agent")
@@ -187,9 +187,9 @@ func TestClient_NewRequest_WithBody(t *testing.T) {
 
 	inURL, _ := "foo", "https://go.example.com/v2/foo"
 	badObject := badObject{}
-	_, err := c.NewRequest("GET", inURL, &badObject)
+	_, err := c.newRequest("GET", inURL, &badObject)
 
 	if err == nil {
-		t.Errorf("NewRequest with body expected error with blank string")
+		t.Errorf("newRequest with body expected error with blank string")
 	}
 }

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -120,7 +121,7 @@ func (s *DomainsService) DeleteDomain(accountID string, domainIdentifier string)
 	path := versioned(domainPath(accountID, domainIdentifier))
 	domainResponse := &domainResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -89,7 +89,7 @@ func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain)
 	path := versioned(domainPath(accountID, ""))
 	domainResponse := &domainResponse{}
 
-	resp, err := s.client.post(path, domainAttributes, domainResponse)
+	resp, err := s.client.post(context.TODO(), path, domainAttributes, domainResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -73,7 +73,7 @@ func (s *DomainsService) ListDomains(accountID string, options *DomainListOption
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, domainsResponse)
+	resp, err := s.client.get(context.TODO(), path, domainsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*
 	path := versioned(domainPath(accountID, domainIdentifier))
 	domainResponse := &domainResponse{}
 
-	resp, err := s.client.get(path, domainResponse)
+	resp, err := s.client.get(context.TODO(), path, domainResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -64,7 +64,7 @@ type DomainListOptions struct {
 // ListDomains lists the domains for an account.
 //
 // See https://developer.dnsimple.com/v2/domains/#list
-func (s *DomainsService) ListDomains(accountID string, options *DomainListOptions) (*DomainsResponse, error) {
+func (s *DomainsService) ListDomains(ctx context.Context, accountID string, options *DomainListOptions) (*DomainsResponse, error) {
 	path := versioned(domainPath(accountID, ""))
 	domainsResponse := &DomainsResponse{}
 
@@ -73,7 +73,7 @@ func (s *DomainsService) ListDomains(accountID string, options *DomainListOption
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, domainsResponse)
+	resp, err := s.client.get(ctx, path, domainsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -85,11 +85,11 @@ func (s *DomainsService) ListDomains(accountID string, options *DomainListOption
 // CreateDomain creates a new domain in the account.
 //
 // See https://developer.dnsimple.com/v2/domains/#create
-func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain) (*DomainResponse, error) {
+func (s *DomainsService) CreateDomain(ctx context.Context, accountID string, domainAttributes Domain) (*DomainResponse, error) {
 	path := versioned(domainPath(accountID, ""))
 	domainResponse := &DomainResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, domainAttributes, domainResponse)
+	resp, err := s.client.post(ctx, path, domainAttributes, domainResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -101,11 +101,11 @@ func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain)
 // GetDomain fetches a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/#get
-func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*DomainResponse, error) {
+func (s *DomainsService) GetDomain(ctx context.Context, accountID string, domainIdentifier string) (*DomainResponse, error) {
 	path := versioned(domainPath(accountID, domainIdentifier))
 	domainResponse := &DomainResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, domainResponse)
+	resp, err := s.client.get(ctx, path, domainResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -117,11 +117,11 @@ func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*
 // DeleteDomain PERMANENTLY deletes a domain from the account.
 //
 // See https://developer.dnsimple.com/v2/domains/#delete
-func (s *DomainsService) DeleteDomain(accountID string, domainIdentifier string) (*DomainResponse, error) {
+func (s *DomainsService) DeleteDomain(ctx context.Context, accountID string, domainIdentifier string) (*DomainResponse, error) {
 	path := versioned(domainPath(accountID, domainIdentifier))
 	domainResponse := &DomainResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -86,7 +87,7 @@ func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier s
 	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
 	collaboratorResponse := &collaboratorResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -46,7 +46,7 @@ type CollaboratorsResponse struct {
 // ListCollaborators list the collaborators for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#list
-func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*CollaboratorsResponse, error) {
+func (s *DomainsService) ListCollaborators(ctx context.Context, accountID, domainIdentifier string, options *ListOptions) (*CollaboratorsResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
 	collaboratorsResponse := &CollaboratorsResponse{}
 
@@ -55,7 +55,7 @@ func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, o
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, collaboratorsResponse)
+	resp, err := s.client.get(ctx, path, collaboratorsResponse)
 	if err != nil {
 		return collaboratorsResponse, err
 	}
@@ -67,11 +67,11 @@ func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, o
 // AddCollaborator adds a new collaborator to the domain in the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*CollaboratorResponse, error) {
+func (s *DomainsService) AddCollaborator(ctx context.Context, accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*CollaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
 	collaboratorResponse := &CollaboratorResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, attributes, collaboratorResponse)
+	resp, err := s.client.post(ctx, path, attributes, collaboratorResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -83,11 +83,11 @@ func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier stri
 // RemoveCollaborator PERMANENTLY deletes a domain from the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#remove
-func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID int64) (*CollaboratorResponse, error) {
+func (s *DomainsService) RemoveCollaborator(ctx context.Context, accountID string, domainIdentifier string, collaboratorID int64) (*CollaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
 	collaboratorResponse := &CollaboratorResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -71,7 +71,7 @@ func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier stri
 	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
 	collaboratorResponse := &collaboratorResponse{}
 
-	resp, err := s.client.post(path, attributes, collaboratorResponse)
+	resp, err := s.client.post(context.TODO(), path, attributes, collaboratorResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -55,7 +55,7 @@ func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, o
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, collaboratorsResponse)
+	resp, err := s.client.get(context.TODO(), path, collaboratorsResponse)
 	if err != nil {
 		return collaboratorsResponse, err
 	}

--- a/dnsimple/domains_collaborators_test.go
+++ b/dnsimple/domains_collaborators_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -32,7 +33,7 @@ func TestDomainsService_ListCollaborators(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	collaboratorsResponse, err := client.Domains.ListCollaborators("1010", "example.com", nil)
+	collaboratorsResponse, err := client.Domains.ListCollaborators(context.Background(), "1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("Domains.ListCollaborators() returned error: %v", err)
 	}
@@ -73,7 +74,7 @@ func TestDomainsService_ListCollaborators_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Domains.ListCollaborators("1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Domains.ListCollaborators(context.Background(), "1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Domains.ListCollaborators() returned error: %v", err)
 	}
@@ -100,7 +101,7 @@ func TestDomainsService_AddCollaborator(t *testing.T) {
 	domainID := "example.com"
 	collaboratorAttributes := CollaboratorAttributes{Email: "existing-user@example.com"}
 
-	collaboratorResponse, err := client.Domains.AddCollaborator(accountID, domainID, collaboratorAttributes)
+	collaboratorResponse, err := client.Domains.AddCollaborator(context.Background(), accountID, domainID, collaboratorAttributes)
 	if err != nil {
 		t.Fatalf("Domains.AddCollaborator() returned error: %v", err)
 	}
@@ -141,7 +142,7 @@ func TestDomainsService_AddNonExistingCollaborator(t *testing.T) {
 	domainID := "example.com"
 	collaboratorAttributes := CollaboratorAttributes{Email: "invited-user@example.com"}
 
-	collaboratorResponse, err := client.Domains.AddCollaborator(accountID, domainID, collaboratorAttributes)
+	collaboratorResponse, err := client.Domains.AddCollaborator(context.Background(), accountID, domainID, collaboratorAttributes)
 	if err != nil {
 		t.Fatalf("Domains.AddCollaborator() returned error: %v", err)
 	}
@@ -179,7 +180,7 @@ func TestDomainsService_RemoveCollaborator(t *testing.T) {
 	domainID := "example.com"
 	collaboratorID := int64(100)
 
-	_, err := client.Domains.RemoveCollaborator(accountID, domainID, collaboratorID)
+	_, err := client.Domains.RemoveCollaborator(context.Background(), accountID, domainID, collaboratorID)
 	if err != nil {
 		t.Fatalf("Domains.RemoveCollaborator() returned error: %v", err)
 	}

--- a/dnsimple/domains_delegation_signer_records.go
+++ b/dnsimple/domains_delegation_signer_records.go
@@ -40,7 +40,7 @@ type DelegationSignerRecordsResponse struct {
 // ListDelegationSignerRecords lists the delegation signer records for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-list
-func (s *DomainsService) ListDelegationSignerRecords(accountID string, domainIdentifier string, options *ListOptions) (*DelegationSignerRecordsResponse, error) {
+func (s *DomainsService) ListDelegationSignerRecords(ctx context.Context, accountID string, domainIdentifier string, options *ListOptions) (*DelegationSignerRecordsResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
 	dsRecordsResponse := &DelegationSignerRecordsResponse{}
 
@@ -49,7 +49,7 @@ func (s *DomainsService) ListDelegationSignerRecords(accountID string, domainIde
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, dsRecordsResponse)
+	resp, err := s.client.get(ctx, path, dsRecordsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -61,11 +61,11 @@ func (s *DomainsService) ListDelegationSignerRecords(accountID string, domainIde
 // CreateDelegationSignerRecord creates a new delegation signer record.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-create
-func (s *DomainsService) CreateDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordAttributes DelegationSignerRecord) (*DelegationSignerRecordResponse, error) {
+func (s *DomainsService) CreateDelegationSignerRecord(ctx context.Context, accountID string, domainIdentifier string, dsRecordAttributes DelegationSignerRecord) (*DelegationSignerRecordResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
 	dsRecordResponse := &DelegationSignerRecordResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, dsRecordAttributes, dsRecordResponse)
+	resp, err := s.client.post(ctx, path, dsRecordAttributes, dsRecordResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -77,11 +77,11 @@ func (s *DomainsService) CreateDelegationSignerRecord(accountID string, domainId
 // GetDelegationSignerRecord fetches a delegation signer record.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-get
-func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int64) (*DelegationSignerRecordResponse, error) {
+func (s *DomainsService) GetDelegationSignerRecord(ctx context.Context, accountID string, domainIdentifier string, dsRecordID int64) (*DelegationSignerRecordResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
 	dsRecordResponse := &DelegationSignerRecordResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, dsRecordResponse)
+	resp, err := s.client.get(ctx, path, dsRecordResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -94,11 +94,11 @@ func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdent
 // from the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-delete
-func (s *DomainsService) DeleteDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int64) (*DelegationSignerRecordResponse, error) {
+func (s *DomainsService) DeleteDelegationSignerRecord(ctx context.Context, accountID string, domainIdentifier string, dsRecordID int64) (*DelegationSignerRecordResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
 	dsRecordResponse := &DelegationSignerRecordResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_delegation_signer_records.go
+++ b/dnsimple/domains_delegation_signer_records.go
@@ -1,6 +1,9 @@
 package dnsimple
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // DelegationSignerRecord represents a delegation signer record for a domain in DNSimple.
 type DelegationSignerRecord struct {
@@ -95,7 +98,7 @@ func (s *DomainsService) DeleteDelegationSignerRecord(accountID string, domainId
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
 	dsRecordResponse := &delegationSignerRecordResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_delegation_signer_records.go
+++ b/dnsimple/domains_delegation_signer_records.go
@@ -49,7 +49,7 @@ func (s *DomainsService) ListDelegationSignerRecords(accountID string, domainIde
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, dsRecordsResponse)
+	resp, err := s.client.get(context.TODO(), path, dsRecordsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdent
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
 	dsRecordResponse := &delegationSignerRecordResponse{}
 
-	resp, err := s.client.get(path, dsRecordResponse)
+	resp, err := s.client.get(context.TODO(), path, dsRecordResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_delegation_signer_records.go
+++ b/dnsimple/domains_delegation_signer_records.go
@@ -65,7 +65,7 @@ func (s *DomainsService) CreateDelegationSignerRecord(accountID string, domainId
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
 	dsRecordResponse := &delegationSignerRecordResponse{}
 
-	resp, err := s.client.post(path, dsRecordAttributes, dsRecordResponse)
+	resp, err := s.client.post(context.TODO(), path, dsRecordAttributes, dsRecordResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_delegation_signer_records_test.go
+++ b/dnsimple/domains_delegation_signer_records_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -32,7 +33,7 @@ func TestDomainsService_ListDelegationSignerRecords(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	dsRecordsResponse, err := client.Domains.ListDelegationSignerRecords("1010", "example.com", nil)
+	dsRecordsResponse, err := client.Domains.ListDelegationSignerRecords(context.Background(), "1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("Domains.ListDelegationSignerRecords() returned error: %v", err)
 	}
@@ -67,7 +68,7 @@ func TestDomainsService_ListDelegationSignerRecords_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Domains.ListDelegationSignerRecords("1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Domains.ListDelegationSignerRecords(context.Background(), "1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Domains.ListDelegationSignerRecords() returned error: %v", err)
 	}
@@ -92,7 +93,7 @@ func TestDomainsService_CreateDelegationSignerRecord(t *testing.T) {
 
 	dsRecordAttributes := DelegationSignerRecord{Algorithm: "13", Digest: "ABC123", DigestType: "2", Keytag: "1234"}
 
-	dsRecordResponse, err := client.Domains.CreateDelegationSignerRecord("1010", "example.com", dsRecordAttributes)
+	dsRecordResponse, err := client.Domains.CreateDelegationSignerRecord(context.Background(), "1010", "example.com", dsRecordAttributes)
 	if err != nil {
 		t.Fatalf("Domains.CreateDelegationSignerRecord() returned error: %v", err)
 	}
@@ -120,7 +121,7 @@ func TestDomainsService_GetDelegationSignerRecord(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	dsRecordResponse, err := client.Domains.GetDelegationSignerRecord("1010", "example.com", 2)
+	dsRecordResponse, err := client.Domains.GetDelegationSignerRecord(context.Background(), "1010", "example.com", 2)
 	if err != nil {
 		t.Errorf("Domains.GetDelegationSignerRecord() returned error: %v", err)
 	}
@@ -155,7 +156,7 @@ func TestDomainsService_DeleteDelegationSignerRecord(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Domains.DeleteDelegationSignerRecord("1010", "example.com", 2)
+	_, err := client.Domains.DeleteDelegationSignerRecord(context.Background(), "1010", "example.com", 2)
 	if err != nil {
 		t.Fatalf("Domains.DeleteDelegationSignerRecord() returned error: %v", err)
 	}

--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -43,7 +44,7 @@ func (s *DomainsService) DisableDnssec(accountID string, domainIdentifier string
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &dnssecResponse{}
 
-	resp, err := s.client.delete(path, dnssecResponse, nil)
+	resp, err := s.client.delete(context.TODO(), path, dnssecResponse, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -60,7 +60,7 @@ func (s *DomainsService) GetDnssec(accountID string, domainIdentifier string) (*
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &dnssecResponse{}
 
-	resp, err := s.client.get(path, dnssecResponse)
+	resp, err := s.client.get(context.TODO(), path, dnssecResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -24,11 +24,11 @@ type DnssecResponse struct {
 // EnableDnssec enables DNSSEC on the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#enableDomainDnssec
-func (s *DomainsService) EnableDnssec(accountID string, domainIdentifier string) (*DnssecResponse, error) {
+func (s *DomainsService) EnableDnssec(ctx context.Context, accountID string, domainIdentifier string) (*DnssecResponse, error) {
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &DnssecResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, dnssecResponse, nil)
+	resp, err := s.client.post(ctx, path, dnssecResponse, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -40,11 +40,11 @@ func (s *DomainsService) EnableDnssec(accountID string, domainIdentifier string)
 // DisableDnssec disables DNSSEC on the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#disableDomainDnssec
-func (s *DomainsService) DisableDnssec(accountID string, domainIdentifier string) (*DnssecResponse, error) {
+func (s *DomainsService) DisableDnssec(ctx context.Context, accountID string, domainIdentifier string) (*DnssecResponse, error) {
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &DnssecResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, dnssecResponse, nil)
+	resp, err := s.client.delete(ctx, path, dnssecResponse, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -56,11 +56,11 @@ func (s *DomainsService) DisableDnssec(accountID string, domainIdentifier string
 // GetDnssec retrieves the current status of DNSSEC on the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#getDomainDnssec
-func (s *DomainsService) GetDnssec(accountID string, domainIdentifier string) (*DnssecResponse, error) {
+func (s *DomainsService) GetDnssec(ctx context.Context, accountID string, domainIdentifier string) (*DnssecResponse, error) {
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &DnssecResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, dnssecResponse)
+	resp, err := s.client.get(ctx, path, dnssecResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -28,7 +28,7 @@ func (s *DomainsService) EnableDnssec(accountID string, domainIdentifier string)
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &dnssecResponse{}
 
-	resp, err := s.client.post(path, dnssecResponse, nil)
+	resp, err := s.client.post(context.TODO(), path, dnssecResponse, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"reflect"
@@ -29,7 +30,7 @@ func TestDomainsService_EnableDnssec(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Domains.EnableDnssec(accountID, "example.com")
+	_, err := client.Domains.EnableDnssec(context.Background(), accountID, "example.com")
 	if err != nil {
 		t.Fatalf("Domains.EnableDnssec() returned error: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestDomainsService_DisableDnssec(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Domains.DisableDnssec(accountID, "example.com")
+	_, err := client.Domains.DisableDnssec(context.Background(), accountID, "example.com")
 	if err != nil {
 		t.Fatalf("Domains.DisableDnssec() returned error: %v", err)
 	}
@@ -70,14 +71,13 @@ func TestDomainsService_GetDnssec(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	dnssecResponse, err := client.Domains.GetDnssec("1010", "example.com")
+	dnssecResponse, err := client.Domains.GetDnssec(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Errorf("Domains.GetDnssec() returned error: %v", err)
 	}
 
 	dnssec := dnssecResponse.Data
-	wantSingle := &Dnssec{
-		Enabled: true}
+	wantSingle := &Dnssec{Enabled: true}
 
 	if !reflect.DeepEqual(dnssec, wantSingle) {
 		t.Fatalf("Domains.GetDnssec() returned %+v, want %+v", dnssec, wantSingle)

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -38,7 +38,7 @@ type EmailForwardsResponse struct {
 // ListEmailForwards lists the email forwards for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#list
-func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier string, options *ListOptions) (*EmailForwardsResponse, error) {
+func (s *DomainsService) ListEmailForwards(ctx context.Context, accountID string, domainIdentifier string, options *ListOptions) (*EmailForwardsResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
 	forwardsResponse := &EmailForwardsResponse{}
 
@@ -47,7 +47,7 @@ func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier st
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, forwardsResponse)
+	resp, err := s.client.get(ctx, path, forwardsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -59,11 +59,11 @@ func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier st
 // CreateEmailForward creates a new email forward.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#create
-func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier string, forwardAttributes EmailForward) (*EmailForwardResponse, error) {
+func (s *DomainsService) CreateEmailForward(ctx context.Context, accountID string, domainIdentifier string, forwardAttributes EmailForward) (*EmailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
 	forwardResponse := &EmailForwardResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, forwardAttributes, forwardResponse)
+	resp, err := s.client.post(ctx, path, forwardAttributes, forwardResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -75,11 +75,11 @@ func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier s
 // GetEmailForward fetches an email forward.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#get
-func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier string, forwardID int64) (*EmailForwardResponse, error) {
+func (s *DomainsService) GetEmailForward(ctx context.Context, accountID string, domainIdentifier string, forwardID int64) (*EmailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
 	forwardResponse := &EmailForwardResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, forwardResponse)
+	resp, err := s.client.get(ctx, path, forwardResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -91,11 +91,11 @@ func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier stri
 // DeleteEmailForward PERMANENTLY deletes an email forward from the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#delete
-func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier string, forwardID int64) (*EmailForwardResponse, error) {
+func (s *DomainsService) DeleteEmailForward(ctx context.Context, accountID string, domainIdentifier string, forwardID int64) (*EmailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
 	forwardResponse := &EmailForwardResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -47,7 +47,7 @@ func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier st
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, forwardsResponse)
+	resp, err := s.client.get(context.TODO(), path, forwardsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier stri
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
 	forwardResponse := &emailForwardResponse{}
 
-	resp, err := s.client.get(path, forwardResponse)
+	resp, err := s.client.get(context.TODO(), path, forwardResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -63,7 +63,7 @@ func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier s
 	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
 	forwardResponse := &emailForwardResponse{}
 
-	resp, err := s.client.post(path, forwardAttributes, forwardResponse)
+	resp, err := s.client.post(context.TODO(), path, forwardAttributes, forwardResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -94,7 +95,7 @@ func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier s
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
 	forwardResponse := &emailForwardResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -35,7 +36,7 @@ func TestDomainsService_EmailForwardsList(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	forwardsResponse, err := client.Domains.ListEmailForwards("1010", "example.com", nil)
+	forwardsResponse, err := client.Domains.ListEmailForwards(context.Background(), "1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("Domains.ListEmailForwards() returned error: %v", err)
 	}
@@ -70,7 +71,7 @@ func TestDomainsService_EmailForwardsList_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Domains.ListEmailForwards("1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Domains.ListEmailForwards(context.Background(), "1010", "example.com", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Domains.ListEmailForwards() returned error: %v", err)
 	}
@@ -95,7 +96,7 @@ func TestDomainsService_CreateEmailForward(t *testing.T) {
 
 	forwardAttributes := EmailForward{From: "me"}
 
-	forwardResponse, err := client.Domains.CreateEmailForward("1010", "example.com", forwardAttributes)
+	forwardResponse, err := client.Domains.CreateEmailForward(context.Background(), "1010", "example.com", forwardAttributes)
 	if err != nil {
 		t.Fatalf("Domains.CreateEmailForward() returned error: %v", err)
 	}
@@ -123,7 +124,7 @@ func TestDomainsService_GetEmailForward(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	forwardResponse, err := client.Domains.GetEmailForward("1010", "example.com", 2)
+	forwardResponse, err := client.Domains.GetEmailForward(context.Background(), "1010", "example.com", 2)
 	if err != nil {
 		t.Errorf("Domains.GetEmailForward() returned error: %v", err)
 	}
@@ -156,7 +157,7 @@ func TestDomainsService_DeleteEmailForward(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Domains.DeleteEmailForward("1010", "example.com", 2)
+	_, err := client.Domains.DeleteEmailForward(context.Background(), "1010", "example.com", 2)
 	if err != nil {
 		t.Fatalf("Domains.DeleteEmailForward() returned error: %v", err)
 	}

--- a/dnsimple/domains_pushes.go
+++ b/dnsimple/domains_pushes.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -101,7 +102,7 @@ func (s *DomainsService) RejectPush(accountID string, pushID int64) (*domainPush
 	path := versioned(domainPushPath(accountID, pushID))
 	pushResponse := &domainPushResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_pushes.go
+++ b/dnsimple/domains_pushes.go
@@ -49,7 +49,7 @@ func (s *DomainsService) InitiatePush(accountID, domainID string, pushAttributes
 	path := versioned(fmt.Sprintf("/%v/pushes", domainPath(accountID, domainID)))
 	pushResponse := &domainPushResponse{}
 
-	resp, err := s.client.post(path, pushAttributes, pushResponse)
+	resp, err := s.client.post(context.TODO(), path, pushAttributes, pushResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (s *DomainsService) AcceptPush(accountID string, pushID int64, pushAttribut
 	path := versioned(domainPushPath(accountID, pushID))
 	pushResponse := &domainPushResponse{}
 
-	resp, err := s.client.post(path, pushAttributes, nil)
+	resp, err := s.client.post(context.TODO(), path, pushAttributes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_pushes.go
+++ b/dnsimple/domains_pushes.go
@@ -70,7 +70,7 @@ func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*do
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, pushesResponse)
+	resp, err := s.client.get(context.TODO(), path, pushesResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_pushes.go
+++ b/dnsimple/domains_pushes.go
@@ -44,12 +44,12 @@ type DomainPushAttributes struct {
 
 // InitiatePush initiate a new domain push.
 //
-// See https://developer.dnsimple.com/v2/domains/pushes/#initiate
-func (s *DomainsService) InitiatePush(accountID, domainID string, pushAttributes DomainPushAttributes) (*DomainPushResponse, error) {
+// See https://developer.dnsimple.com/v2/domains/pushes/#initiateDomainPush
+func (s *DomainsService) InitiatePush(ctx context.Context, accountID, domainID string, pushAttributes DomainPushAttributes) (*DomainPushResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/pushes", domainPath(accountID, domainID)))
 	pushResponse := &DomainPushResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, pushAttributes, pushResponse)
+	resp, err := s.client.post(ctx, path, pushAttributes, pushResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +60,8 @@ func (s *DomainsService) InitiatePush(accountID, domainID string, pushAttributes
 
 // ListPushes lists the pushes for an account.
 //
-// See https://developer.dnsimple.com/v2/domains/pushes/#list
-func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*DomainPushesResponse, error) {
+// See https://developer.dnsimple.com/v2/domains/pushes/#listPushes
+func (s *DomainsService) ListPushes(ctx context.Context, accountID string, options *ListOptions) (*DomainPushesResponse, error) {
 	path := versioned(domainPushPath(accountID, 0))
 	pushesResponse := &DomainPushesResponse{}
 
@@ -70,7 +70,7 @@ func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*Do
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, pushesResponse)
+	resp, err := s.client.get(ctx, path, pushesResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -81,12 +81,12 @@ func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*Do
 
 // AcceptPush accept a push for a domain.
 //
-// See https://developer.dnsimple.com/v2/domains/pushes/#accept
-func (s *DomainsService) AcceptPush(accountID string, pushID int64, pushAttributes DomainPushAttributes) (*DomainPushResponse, error) {
+// See https://developer.dnsimple.com/v2/domains/pushes/#acceptPush
+func (s *DomainsService) AcceptPush(ctx context.Context, accountID string, pushID int64, pushAttributes DomainPushAttributes) (*DomainPushResponse, error) {
 	path := versioned(domainPushPath(accountID, pushID))
 	pushResponse := &DomainPushResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, pushAttributes, nil)
+	resp, err := s.client.post(ctx, path, pushAttributes, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -97,12 +97,12 @@ func (s *DomainsService) AcceptPush(accountID string, pushID int64, pushAttribut
 
 // RejectPush reject a push for a domain.
 //
-// See https://developer.dnsimple.com/v2/domains/pushes/#reject
-func (s *DomainsService) RejectPush(accountID string, pushID int64) (*DomainPushResponse, error) {
+// See https://developer.dnsimple.com/v2/domains/pushes/#rejectPush
+func (s *DomainsService) RejectPush(ctx context.Context, accountID string, pushID int64) (*DomainPushResponse, error) {
 	path := versioned(domainPushPath(accountID, pushID))
 	pushResponse := &DomainPushResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_pushes_test.go
+++ b/dnsimple/domains_pushes_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -37,7 +38,7 @@ func TestDomainsService_InitiatePush(t *testing.T) {
 
 	pushAttributes := DomainPushAttributes{NewAccountEmail: "admin@target-account.test"}
 
-	pushResponse, err := client.Domains.InitiatePush("1010", "example.com", pushAttributes)
+	pushResponse, err := client.Domains.InitiatePush(context.Background(), "1010", "example.com", pushAttributes)
 	if err != nil {
 		t.Fatalf("Domains.InitiatePush() returned error: %v", err)
 	}
@@ -65,7 +66,7 @@ func TestDomainsService_DomainsPushesList(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	pushesResponse, err := client.Domains.ListPushes("2020", nil)
+	pushesResponse, err := client.Domains.ListPushes(context.Background(), "2020", nil)
 	if err != nil {
 		t.Fatalf("Domains.ListPushes() returned error: %v", err)
 	}
@@ -100,7 +101,7 @@ func TestDomainsService_DomainsPushesList_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Domains.ListPushes("2020", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Domains.ListPushes(context.Background(), "2020", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Domains.ListPushes() returned error: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestDomainsService_AcceptPush(t *testing.T) {
 
 	pushAttributes := DomainPushAttributes{ContactID: 2}
 
-	_, err := client.Domains.AcceptPush("2020", 1, pushAttributes)
+	_, err := client.Domains.AcceptPush(context.Background(), "2020", 1, pushAttributes)
 	if err != nil {
 		t.Fatalf("Domains.AcceptPush() returned error: %v", err)
 	}
@@ -145,7 +146,7 @@ func TestDomainsService_RejectPush(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Domains.RejectPush("2020", 1)
+	_, err := client.Domains.RejectPush(context.Background(), "2020", 1)
 	if err != nil {
 		t.Fatalf("Domains.RejectPush() returned error: %v", err)
 	}

--- a/dnsimple/domains_test.go
+++ b/dnsimple/domains_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func TestDomainsService_ListDomains(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	domainsResponse, err := client.Domains.ListDomains("1010", nil)
+	domainsResponse, err := client.Domains.ListDomains(context.Background(), "1010", nil)
 	if err != nil {
 		t.Fatalf("Domains.ListDomains() returned error: %v", err)
 	}
@@ -74,7 +75,7 @@ func TestDomainsService_ListDomains_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Domains.ListDomains("1010", &DomainListOptions{"example", 10, ListOptions{Page: 2, PerPage: 20, Sort: "name,expiration:desc"}})
+	_, err := client.Domains.ListDomains(context.Background(), "1010", &DomainListOptions{"example", 10, ListOptions{Page: 2, PerPage: 20, Sort: "name,expiration:desc"}})
 	if err != nil {
 		t.Fatalf("Domains.ListDomains() returned error: %v", err)
 	}
@@ -100,7 +101,7 @@ func TestDomainsService_CreateDomain(t *testing.T) {
 	accountID := "1"
 	domainAttributes := Domain{Name: "example.com"}
 
-	domainResponse, err := client.Domains.CreateDomain(accountID, domainAttributes)
+	domainResponse, err := client.Domains.CreateDomain(context.Background(), accountID, domainAttributes)
 	if err != nil {
 		t.Fatalf("Domains.Create() returned error: %v", err)
 	}
@@ -130,7 +131,7 @@ func TestDomainsService_GetDomain(t *testing.T) {
 
 	accountID := "1010"
 
-	domainResponse, err := client.Domains.GetDomain(accountID, "example.com")
+	domainResponse, err := client.Domains.GetDomain(context.Background(), accountID, "example.com")
 	if err != nil {
 		t.Errorf("Domains.Get() returned error: %v", err)
 	}
@@ -170,7 +171,7 @@ func TestDomainsService_DeleteDomain(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Domains.DeleteDomain(accountID, "example.com")
+	_, err := client.Domains.DeleteDomain(context.Background(), accountID, "example.com")
 	if err != nil {
 		t.Fatalf("Domains.Delete() returned error: %v", err)
 	}

--- a/dnsimple/identity.go
+++ b/dnsimple/identity.go
@@ -28,11 +28,11 @@ type WhoamiResponse struct {
 // Whoami gets the current authenticate context.
 //
 // See https://developer.dnsimple.com/v2/whoami
-func (s *IdentityService) Whoami() (*WhoamiResponse, error) {
+func (s *IdentityService) Whoami(ctx context.Context) (*WhoamiResponse, error) {
 	path := versioned("/whoami")
 	whoamiResponse := &WhoamiResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, whoamiResponse)
+	resp, err := s.client.get(ctx, path, whoamiResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -41,10 +41,9 @@ func (s *IdentityService) Whoami() (*WhoamiResponse, error) {
 	return whoamiResponse, nil
 }
 
-// Whoami is a state-less shortcut to client.Whoami()
-// that returns only the relevant Data.
-func Whoami(c *Client) (data *WhoamiData, err error) {
-	resp, err := c.Identity.Whoami()
+// Whoami is a state-less shortcut to client.Whoami() that returns only the relevant Data.
+func Whoami(ctx context.Context, c *Client) (data *WhoamiData, err error) {
+	resp, err := c.Identity.Whoami(ctx)
 	if resp != nil {
 		data = resp.Data
 	}

--- a/dnsimple/identity.go
+++ b/dnsimple/identity.go
@@ -1,5 +1,9 @@
 package dnsimple
 
+import (
+	"context"
+)
+
 // IdentityService handles communication with several authentication identity
 // methods of the DNSimple API.
 //
@@ -28,7 +32,7 @@ func (s *IdentityService) Whoami() (*whoamiResponse, error) {
 	path := versioned("/whoami")
 	whoamiResponse := &whoamiResponse{}
 
-	resp, err := s.client.get(path, whoamiResponse)
+	resp, err := s.client.get(context.TODO(), path, whoamiResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/identity_test.go
+++ b/dnsimple/identity_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -20,7 +21,7 @@ func TestAuthService_Whoami(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	whoamiResponse, err := client.Identity.Whoami()
+	whoamiResponse, err := client.Identity.Whoami(context.Background())
 	if err != nil {
 		t.Fatalf("Identity.Whoami() returned error: %v", err)
 	}

--- a/dnsimple/live_test.go
+++ b/dnsimple/live_test.go
@@ -42,7 +42,7 @@ func TestLive_Whoami(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	whoamiResponse, err := dnsimpleClient.Identity.Whoami()
+	whoamiResponse, err := dnsimpleClient.Identity.Whoami(context.Background())
 	if err != nil {
 		t.Fatalf("Live Auth.Whoami() returned error: %v", err)
 	}
@@ -58,14 +58,14 @@ func TestLive_Domains(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	whoami, err := Whoami(dnsimpleClient)
+	whoami, err := Whoami(context.Background(), dnsimpleClient)
 	if err != nil {
 		t.Fatalf("Live Whoami() returned error: %v", err)
 	}
 
 	accountID := whoami.Account.ID
 
-	domainsResponse, err := dnsimpleClient.Domains.ListDomains(fmt.Sprintf("%v", accountID), nil)
+	domainsResponse, err := dnsimpleClient.Domains.ListDomains(context.Background(), fmt.Sprintf("%v", accountID), nil)
 	if err != nil {
 		t.Fatalf("Live Domains.List() returned error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestLive_Registration(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	whoami, err := Whoami(dnsimpleClient)
+	whoami, err := Whoami(context.Background(), dnsimpleClient)
 	if err != nil {
 		t.Fatalf("Live Whoami() returned error: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestLive_Registration(t *testing.T) {
 
 	// TODO: fetch the registrant randomly
 	registerRequest := &DomainRegisterRequest{RegistrantID: 2}
-	registrationResponse, err := dnsimpleClient.Registrar.RegisterDomain(fmt.Sprintf("%v", accountID), fmt.Sprintf("example-%v.com", time.Now().Unix()), registerRequest)
+	registrationResponse, err := dnsimpleClient.Registrar.RegisterDomain(context.Background(), fmt.Sprintf("%v", accountID), fmt.Sprintf("example-%v.com", time.Now().Unix()), registerRequest)
 	if err != nil {
 		t.Fatalf("Live Registrar.Register() returned error: %v", err)
 	}
@@ -107,13 +107,13 @@ func TestLive_Webhooks(t *testing.T) {
 	var webhookResponse *WebhookResponse
 	var webhooksResponse *WebhooksResponse
 
-	whoami, err := Whoami(dnsimpleClient)
+	whoami, err := Whoami(context.Background(), dnsimpleClient)
 	if err != nil {
 		t.Fatalf("Live Auth.Whoami()/Domains.List() returned error: %v", err)
 	}
 	accountID := whoami.Account.ID
 
-	webhooksResponse, err = dnsimpleClient.Webhooks.ListWebhooks(fmt.Sprintf("%v", accountID), nil)
+	webhooksResponse, err = dnsimpleClient.Webhooks.ListWebhooks(context.Background(), fmt.Sprintf("%v", accountID), nil)
 	if err != nil {
 		t.Fatalf("Live Webhooks.List() returned error: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestLive_Webhooks(t *testing.T) {
 	fmt.Printf("Webhooks: %+v\n", webhooksResponse.Data)
 
 	webhookAttributes := Webhook{URL: "https://livetest.test"}
-	webhookResponse, err = dnsimpleClient.Webhooks.CreateWebhook(fmt.Sprintf("%v", accountID), webhookAttributes)
+	webhookResponse, err = dnsimpleClient.Webhooks.CreateWebhook(context.Background(), fmt.Sprintf("%v", accountID), webhookAttributes)
 	if err != nil {
 		t.Fatalf("Live Webhooks.Create() returned error: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestLive_Webhooks(t *testing.T) {
 	fmt.Printf("Webhook: %+v\n", webhookResponse.Data)
 	webhook = webhookResponse.Data
 
-	webhookResponse, err = dnsimpleClient.Webhooks.DeleteWebhook(fmt.Sprintf("%v", accountID), webhook.ID)
+	webhookResponse, err = dnsimpleClient.Webhooks.DeleteWebhook(context.Background(), fmt.Sprintf("%v", accountID), webhook.ID)
 	if err != nil {
 		t.Fatalf("Live Webhooks.Delete(%v) returned error: %v", webhook.ID, err)
 	}
@@ -145,20 +145,20 @@ func TestLive_Zones(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	whoami, err := Whoami(dnsimpleClient)
+	whoami, err := Whoami(context.Background(), dnsimpleClient)
 	if err != nil {
 		t.Fatalf("Live Zones/Whoami() returned error: %v", err)
 	}
 
 	accountID := fmt.Sprintf("%v", whoami.Account.ID)
 
-	domainResponse, err := dnsimpleClient.Domains.CreateDomain(accountID, Domain{Name: fmt.Sprintf("example-%v.test", time.Now().Unix())})
+	domainResponse, err := dnsimpleClient.Domains.CreateDomain(context.Background(), accountID, Domain{Name: fmt.Sprintf("example-%v.test", time.Now().Unix())})
 	if err != nil {
 		t.Fatalf("Live Zones/CreateZone() returned error: %v", err)
 	}
 
 	zoneName := domainResponse.Data.Name
-	recordResponse, err := dnsimpleClient.Zones.CreateRecord(accountID, zoneName, ZoneRecord{Name: fmt.Sprintf("%v", time.Now().Unix()), Type: "TXT", Content: "Test"})
+	recordResponse, err := dnsimpleClient.Zones.CreateRecord(context.Background(), accountID, zoneName, ZoneRecord{Name: fmt.Sprintf("%v", time.Now().Unix()), Type: "TXT", Content: "Test"})
 	if err != nil {
 		t.Fatalf("Live Zones/CreateRecord() returned error: %v", err)
 	}
@@ -171,12 +171,12 @@ func TestLive_Error(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	whoami, err := Whoami(dnsimpleClient)
+	whoami, err := Whoami(context.Background(), dnsimpleClient)
 	if err != nil {
 		t.Fatalf("Live Error/Whoami() returned error: %v", err)
 	}
 
-	_, err = dnsimpleClient.Registrar.RegisterDomain(fmt.Sprintf("%v", whoami.Account.ID), fmt.Sprintf("example-%v.test", time.Now().Unix()), &DomainRegisterRequest{})
+	_, err = dnsimpleClient.Registrar.RegisterDomain(context.Background(), fmt.Sprintf("%v", whoami.Account.ID), fmt.Sprintf("example-%v.test", time.Now().Unix()), &DomainRegisterRequest{})
 	if err == nil {
 		t.Fatalf("Live Error/RegisterDomain() expected to return error")
 	}

--- a/dnsimple/oauth.go
+++ b/dnsimple/oauth.go
@@ -67,7 +67,7 @@ func (r *ExchangeAuthorizationError) Error() string {
 func (s *OauthService) ExchangeAuthorizationForToken(authorization *ExchangeAuthorizationRequest) (*AccessToken, error) {
 	path := versioned("/oauth/access_token")
 
-	req, err := s.client.NewRequest("POST", path, authorization)
+	req, err := s.client.newRequest("POST", path, authorization)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -33,7 +33,7 @@ func (s *RegistrarService) CheckDomain(accountID string, domainName string) (*do
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/check", accountID, domainName))
 	checkResponse := &domainCheckResponse{}
 
-	resp, err := s.client.get(path, checkResponse)
+	resp, err := s.client.get(context.TODO(), path, checkResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (s *RegistrarService) GetDomainPremiumPrice(accountID string, domainName st
 		}
 	}
 
-	resp, err := s.client.get(path, priceResponse)
+	resp, err := s.client.get(context.TODO(), path, priceResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -136,7 +137,7 @@ func (s *RegistrarService) RegisterDomain(accountID string, domainName string, r
 
 	// TODO: validate mandatory attributes RegistrantID
 
-	resp, err := s.client.post(path, request, registrationResponse)
+	resp, err := s.client.post(context.TODO(), path, request, registrationResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +193,7 @@ func (s *RegistrarService) TransferDomain(accountID string, domainName string, r
 
 	// TODO: validate mandatory attributes RegistrantID
 
-	resp, err := s.client.post(path, request, transferResponse)
+	resp, err := s.client.post(context.TODO(), path, request, transferResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (s *RegistrarService) TransferDomainOut(accountID string, domainName string
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/authorize_transfer_out", accountID, domainName))
 	transferResponse := &domainTransferOutResponse{}
 
-	resp, err := s.client.post(path, nil, nil)
+	resp, err := s.client.post(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +256,7 @@ func (s *RegistrarService) RenewDomain(accountID string, domainName string, requ
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/renewals", accountID, domainName))
 	renewalResponse := &domainRenewalResponse{}
 
-	resp, err := s.client.post(path, request, renewalResponse)
+	resp, err := s.client.post(context.TODO(), path, request, renewalResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -29,11 +29,11 @@ type DomainCheckResponse struct {
 // CheckDomain checks a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#check
-func (s *RegistrarService) CheckDomain(accountID string, domainName string) (*DomainCheckResponse, error) {
+func (s *RegistrarService) CheckDomain(ctx context.Context, accountID string, domainName string) (*DomainCheckResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/check", accountID, domainName))
 	checkResponse := &DomainCheckResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, checkResponse)
+	resp, err := s.client.get(ctx, path, checkResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ type DomainPremiumPriceOptions struct {
 // - renewal
 //
 // See https://developer.dnsimple.com/v2/registrar/#premium-price
-func (s *RegistrarService) GetDomainPremiumPrice(accountID string, domainName string, options *DomainPremiumPriceOptions) (*DomainPremiumPriceResponse, error) {
+func (s *RegistrarService) GetDomainPremiumPrice(ctx context.Context, accountID string, domainName string, options *DomainPremiumPriceOptions) (*DomainPremiumPriceResponse, error) {
 	var err error
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/premium_price", accountID, domainName))
 	priceResponse := &DomainPremiumPriceResponse{}
@@ -83,7 +83,7 @@ func (s *RegistrarService) GetDomainPremiumPrice(accountID string, domainName st
 		}
 	}
 
-	resp, err := s.client.get(context.TODO(), path, priceResponse)
+	resp, err := s.client.get(ctx, path, priceResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -131,13 +131,13 @@ type DomainRegisterRequest struct {
 // RegisterDomain registers a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#register
-func (s *RegistrarService) RegisterDomain(accountID string, domainName string, request *DomainRegisterRequest) (*DomainRegistrationResponse, error) {
+func (s *RegistrarService) RegisterDomain(ctx context.Context, accountID string, domainName string, request *DomainRegisterRequest) (*DomainRegistrationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/registrations", accountID, domainName))
 	registrationResponse := &DomainRegistrationResponse{}
 
 	// TODO: validate mandatory attributes RegistrantID
 
-	resp, err := s.client.post(context.TODO(), path, request, registrationResponse)
+	resp, err := s.client.post(ctx, path, request, registrationResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -187,13 +187,13 @@ type DomainTransferRequest struct {
 // TransferDomain transfers a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#transferDomain
-func (s *RegistrarService) TransferDomain(accountID string, domainName string, request *DomainTransferRequest) (*DomainTransferResponse, error) {
+func (s *RegistrarService) TransferDomain(ctx context.Context, accountID string, domainName string, request *DomainTransferRequest) (*DomainTransferResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfers", accountID, domainName))
 	transferResponse := &DomainTransferResponse{}
 
 	// TODO: validate mandatory attributes RegistrantID
 
-	resp, err := s.client.post(context.TODO(), path, request, transferResponse)
+	resp, err := s.client.post(ctx, path, request, transferResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -211,11 +211,11 @@ type DomainTransferOutResponse struct {
 // TransferDomainOut prepares a domain for outbound transfer.
 //
 // See https://developer.dnsimple.com/v2/registrar/#authorizeDomainTransferOut
-func (s *RegistrarService) TransferDomainOut(accountID string, domainName string) (*DomainTransferOutResponse, error) {
+func (s *RegistrarService) TransferDomainOut(ctx context.Context, accountID string, domainName string) (*DomainTransferOutResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/authorize_transfer_out", accountID, domainName))
 	transferResponse := &DomainTransferOutResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, nil, nil)
+	resp, err := s.client.post(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -252,11 +252,11 @@ type DomainRenewRequest struct {
 // RenewDomain renews a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#register
-func (s *RegistrarService) RenewDomain(accountID string, domainName string, request *DomainRenewRequest) (*DomainRenewalResponse, error) {
+func (s *RegistrarService) RenewDomain(ctx context.Context, accountID string, domainName string, request *DomainRenewRequest) (*DomainRenewalResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/renewals", accountID, domainName))
 	renewalResponse := &DomainRenewalResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, request, renewalResponse)
+	resp, err := s.client.post(ctx, path, request, renewalResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_auto_renewal.go
+++ b/dnsimple/registrar_auto_renewal.go
@@ -8,11 +8,11 @@ import (
 // EnableDomainAutoRenewal enables auto-renewal for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
-func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName string) (*DomainResponse, error) {
+func (s *RegistrarService) EnableDomainAutoRenewal(ctx context.Context, accountID string, domainName string) (*DomainResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
 	domainResponse := &DomainResponse{}
 
-	resp, err := s.client.put(context.TODO(), path, nil, nil)
+	resp, err := s.client.put(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -24,11 +24,11 @@ func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName 
 // DisableDomainAutoRenewal disables auto-renewal for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
-func (s *RegistrarService) DisableDomainAutoRenewal(accountID string, domainName string) (*DomainResponse, error) {
+func (s *RegistrarService) DisableDomainAutoRenewal(ctx context.Context, accountID string, domainName string) (*DomainResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
 	domainResponse := &DomainResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_auto_renewal.go
+++ b/dnsimple/registrar_auto_renewal.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -27,7 +28,7 @@ func (s *RegistrarService) DisableDomainAutoRenewal(accountID string, domainName
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
 	domainResponse := &domainResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_auto_renewal.go
+++ b/dnsimple/registrar_auto_renewal.go
@@ -12,7 +12,7 @@ func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName 
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
 	domainResponse := &domainResponse{}
 
-	resp, err := s.client.put(path, nil, nil)
+	resp, err := s.client.put(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_auto_renewal_test.go
+++ b/dnsimple/registrar_auto_renewal_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -20,7 +21,7 @@ func TestRegistrarService_EnableDomainAutoRenewal(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Registrar.EnableDomainAutoRenewal(accountID, "example.com")
+	_, err := client.Registrar.EnableDomainAutoRenewal(context.Background(), accountID, "example.com")
 	if err != nil {
 		t.Fatalf("Registrars.EnableDomainAutoRenewal() returned error: %v", err)
 	}
@@ -41,7 +42,7 @@ func TestRegistrarService_DisableDomainAutoRenewal(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Registrar.DisableDomainAutoRenewal(accountID, "example.com")
+	_, err := client.Registrar.DisableDomainAutoRenewal(context.Background(), accountID, "example.com")
 	if err != nil {
 		t.Fatalf("Registrars.DisableDomainAutoRenewal() returned error: %v", err)
 	}

--- a/dnsimple/registrar_delegation.go
+++ b/dnsimple/registrar_delegation.go
@@ -23,11 +23,11 @@ type VanityDelegationResponse struct {
 // GetDomainDelegation gets the current delegated name servers for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#get
-func (s *RegistrarService) GetDomainDelegation(accountID string, domainName string) (*DelegationResponse, error) {
+func (s *RegistrarService) GetDomainDelegation(ctx context.Context, accountID string, domainName string) (*DelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
 	delegationResponse := &DelegationResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, delegationResponse)
+	resp, err := s.client.get(ctx, path, delegationResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -39,11 +39,11 @@ func (s *RegistrarService) GetDomainDelegation(accountID string, domainName stri
 // ChangeDomainDelegation updates the delegated name severs for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#get
-func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName string, newDelegation *Delegation) (*DelegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegation(ctx context.Context, accountID string, domainName string, newDelegation *Delegation) (*DelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
 	delegationResponse := &DelegationResponse{}
 
-	resp, err := s.client.put(context.TODO(), path, newDelegation, delegationResponse)
+	resp, err := s.client.put(ctx, path, newDelegation, delegationResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -55,11 +55,11 @@ func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName s
 // ChangeDomainDelegationToVanity enables vanity name servers for the given domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#delegateToVanity
-func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, domainName string, newDelegation *Delegation) (*VanityDelegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegationToVanity(ctx context.Context, accountID string, domainName string, newDelegation *Delegation) (*VanityDelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
 	delegationResponse := &VanityDelegationResponse{}
 
-	resp, err := s.client.put(context.TODO(), path, newDelegation, delegationResponse)
+	resp, err := s.client.put(ctx, path, newDelegation, delegationResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -71,11 +71,11 @@ func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, doma
 // ChangeDomainDelegationFromVanity disables vanity name servers for the given domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#dedelegateFromVanity
-func (s *RegistrarService) ChangeDomainDelegationFromVanity(accountID string, domainName string) (*VanityDelegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegationFromVanity(ctx context.Context, accountID string, domainName string) (*VanityDelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
 	delegationResponse := &VanityDelegationResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_delegation.go
+++ b/dnsimple/registrar_delegation.go
@@ -27,7 +27,7 @@ func (s *RegistrarService) GetDomainDelegation(accountID string, domainName stri
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
 	delegationResponse := &delegationResponse{}
 
-	resp, err := s.client.get(path, delegationResponse)
+	resp, err := s.client.get(context.TODO(), path, delegationResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_delegation.go
+++ b/dnsimple/registrar_delegation.go
@@ -43,7 +43,7 @@ func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName s
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
 	delegationResponse := &delegationResponse{}
 
-	resp, err := s.client.put(path, newDelegation, delegationResponse)
+	resp, err := s.client.put(context.TODO(), path, newDelegation, delegationResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, doma
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
 	delegationResponse := &vanityDelegationResponse{}
 
-	resp, err := s.client.put(path, newDelegation, delegationResponse)
+	resp, err := s.client.put(context.TODO(), path, newDelegation, delegationResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_delegation.go
+++ b/dnsimple/registrar_delegation.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -74,7 +75,7 @@ func (s *RegistrarService) ChangeDomainDelegationFromVanity(accountID string, do
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
 	delegationResponse := &vanityDelegationResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_delegation_test.go
+++ b/dnsimple/registrar_delegation_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"reflect"
@@ -21,7 +22,7 @@ func TestRegistrarService_GetDomainDelegation(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	delegationResponse, err := client.Registrar.GetDomainDelegation("1010", "example.com")
+	delegationResponse, err := client.Registrar.GetDomainDelegation(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Fatalf("Registrar.GetDomainDelegation() returned error: %v", err)
 	}
@@ -53,7 +54,7 @@ func TestRegistrarService_ChangeDomainDelegation(t *testing.T) {
 
 	newDelegation := &Delegation{"ns1.dnsimple.com", "ns2.dnsimple.com"}
 
-	delegationResponse, err := client.Registrar.ChangeDomainDelegation("1010", "example.com", newDelegation)
+	delegationResponse, err := client.Registrar.ChangeDomainDelegation(context.Background(), "1010", "example.com", newDelegation)
 	if err != nil {
 		t.Fatalf("Registrar.ChangeDomainDelegation() returned error: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestRegistrarService_ChangeDomainDelegationToVanity(t *testing.T) {
 
 	newDelegation := &Delegation{"ns1.example.com", "ns2.example.com"}
 
-	delegationResponse, err := client.Registrar.ChangeDomainDelegationToVanity("1010", "example.com", newDelegation)
+	delegationResponse, err := client.Registrar.ChangeDomainDelegationToVanity(context.Background(), "1010", "example.com", newDelegation)
 	if err != nil {
 		t.Fatalf("Registrar.ChangeDomainDelegationToVanity() returned error: %v", err)
 	}
@@ -112,7 +113,7 @@ func TestRegistrarService_ChangeDomainDelegationFromVanity(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Registrar.ChangeDomainDelegationFromVanity("1010", "example.com")
+	_, err := client.Registrar.ChangeDomainDelegationFromVanity(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Fatalf("Registrar.ChangeDomainDelegationFromVanity() returned error: %v", err)
 	}

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,7 +23,7 @@ func TestRegistrarService_CheckDomain(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	checkResponse, err := client.Registrar.CheckDomain("1010", "example.com")
+	checkResponse, err := client.Registrar.CheckDomain(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Fatalf("Registrar.CheckDomain() returned error: %v", err)
 	}
@@ -47,7 +48,7 @@ func TestRegistrarService_GetDomainPremiumPrice(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	priceResponse, err := client.Registrar.GetDomainPremiumPrice("1010", "example.com", nil)
+	priceResponse, err := client.Registrar.GetDomainPremiumPrice(context.Background(), "1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("Registrar.GetDomainPremiumPrice() returned error: %v", err)
 	}
@@ -76,7 +77,7 @@ func TestRegistrarService_GetDomainPremiumPrice_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Registrar.GetDomainPremiumPrice("1010", "example.com", &DomainPremiumPriceOptions{Action: "registration"})
+	_, err := client.Registrar.GetDomainPremiumPrice(context.Background(), "1010", "example.com", &DomainPremiumPriceOptions{Action: "registration"})
 	if err != nil {
 		t.Fatalf("Registrar.GetDomainPremiumPrice() returned error: %v", err)
 	}
@@ -101,7 +102,7 @@ func TestRegistrarService_RegisterDomain(t *testing.T) {
 
 	registerRequest := &DomainRegisterRequest{RegistrantID: 2}
 
-	registrationResponse, err := client.Registrar.RegisterDomain("1010", "example.com", registerRequest)
+	registrationResponse, err := client.Registrar.RegisterDomain(context.Background(), "1010", "example.com", registerRequest)
 	if err != nil {
 		t.Fatalf("Registrar.RegisterDomain() returned error: %v", err)
 	}
@@ -134,7 +135,7 @@ func TestRegistrarService_RegisterDomain_ExtendedAttributes(t *testing.T) {
 
 	registerRequest := &DomainRegisterRequest{RegistrantID: 2, ExtendedAttributes: map[string]string{"att1": "val1", "att2": "val2"}}
 
-	if _, err := client.Registrar.RegisterDomain("1010", "example.com", registerRequest); err != nil {
+	if _, err := client.Registrar.RegisterDomain(context.Background(), "1010", "example.com", registerRequest); err != nil {
 		t.Fatalf("Registrar.RegisterDomain() returned error: %v", err)
 	}
 }
@@ -158,7 +159,7 @@ func TestRegistrarService_TransferDomain(t *testing.T) {
 
 	transferRequest := &DomainTransferRequest{RegistrantID: 2, AuthCode: "x1y2z3"}
 
-	transferResponse, err := client.Registrar.TransferDomain("1010", "example.com", transferRequest)
+	transferResponse, err := client.Registrar.TransferDomain(context.Background(), "1010", "example.com", transferRequest)
 	if err != nil {
 		t.Fatalf("Registrar.TransferDomain() returned error: %v", err)
 	}
@@ -191,7 +192,7 @@ func TestRegistrarService_TransferDomain_ExtendedAttributes(t *testing.T) {
 
 	transferRequest := &DomainTransferRequest{RegistrantID: 2, AuthCode: "x1y2z3", ExtendedAttributes: map[string]string{"att1": "val1", "att2": "val2"}}
 
-	if _, err := client.Registrar.TransferDomain("1010", "example.com", transferRequest); err != nil {
+	if _, err := client.Registrar.TransferDomain(context.Background(), "1010", "example.com", transferRequest); err != nil {
 		t.Fatalf("Registrar.TransferDomain() returned error: %v", err)
 	}
 }
@@ -210,7 +211,7 @@ func TestRegistrarService_TransferDomainOut(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Registrar.TransferDomainOut("1010", "example.com")
+	_, err := client.Registrar.TransferDomainOut(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Fatalf("Registrar.TransferOut() returned error: %v", err)
 	}
@@ -233,7 +234,7 @@ func TestRegistrarService_RenewDomain(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	renewalResponse, err := client.Registrar.RenewDomain("1010", "example.com", nil)
+	renewalResponse, err := client.Registrar.RenewDomain(context.Background(), "1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("Registrar.RenewDomain() returned error: %v", err)
 	}

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -94,7 +94,7 @@ func (s *RegistrarService) RenewWhoisPrivacy(accountID string, domainName string
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy/renewals", accountID, domainName))
 	privacyRenewalResponse := &whoisPrivacyRenewalResponse{}
 
-	resp, err := s.client.post(path, nil, privacyRenewalResponse)
+	resp, err := s.client.post(context.TODO(), path, nil, privacyRenewalResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -62,7 +62,7 @@ func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName strin
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
 	privacyResponse := &whoisPrivacyResponse{}
 
-	resp, err := s.client.put(path, nil, privacyResponse)
+	resp, err := s.client.put(context.TODO(), path, nil, privacyResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -42,11 +42,11 @@ type WhoisPrivacyRenewalResponse struct {
 // GetWhoisPrivacy gets the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#get
-func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
+func (s *RegistrarService) GetWhoisPrivacy(ctx context.Context, accountID string, domainName string) (*WhoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
 	privacyResponse := &WhoisPrivacyResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, privacyResponse)
+	resp, err := s.client.get(ctx, path, privacyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -58,11 +58,11 @@ func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) 
 // EnableWhoisPrivacy enables the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
-func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
+func (s *RegistrarService) EnableWhoisPrivacy(ctx context.Context, accountID string, domainName string) (*WhoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
 	privacyResponse := &WhoisPrivacyResponse{}
 
-	resp, err := s.client.put(context.TODO(), path, nil, privacyResponse)
+	resp, err := s.client.put(ctx, path, nil, privacyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -74,11 +74,11 @@ func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName strin
 // DisableWhoisPrivacy disables the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
-func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
+func (s *RegistrarService) DisableWhoisPrivacy(ctx context.Context, accountID string, domainName string) (*WhoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
 	privacyResponse := &WhoisPrivacyResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, privacyResponse)
+	resp, err := s.client.delete(ctx, path, nil, privacyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -90,11 +90,11 @@ func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName stri
 // RenewWhoisPrivacy renews the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#renew
-func (s *RegistrarService) RenewWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyRenewalResponse, error) {
+func (s *RegistrarService) RenewWhoisPrivacy(ctx context.Context, accountID string, domainName string) (*WhoisPrivacyRenewalResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy/renewals", accountID, domainName))
 	privacyRenewalResponse := &WhoisPrivacyRenewalResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, nil, privacyRenewalResponse)
+	resp, err := s.client.post(ctx, path, nil, privacyRenewalResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -46,7 +46,7 @@ func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) 
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
 	privacyResponse := &whoisPrivacyResponse{}
 
-	resp, err := s.client.get(path, privacyResponse)
+	resp, err := s.client.get(context.TODO(), path, privacyResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -77,7 +78,7 @@ func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName stri
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
 	privacyResponse := &whoisPrivacyResponse{}
 
-	resp, err := s.client.delete(path, nil, privacyResponse)
+	resp, err := s.client.delete(context.TODO(), path, nil, privacyResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/registrar_whois_privacy_test.go
+++ b/dnsimple/registrar_whois_privacy_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"reflect"
@@ -21,7 +22,7 @@ func TestRegistrarService_GetWhoisPrivacy(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	privacyResponse, err := client.Registrar.GetWhoisPrivacy("1010", "example.com")
+	privacyResponse, err := client.Registrar.GetWhoisPrivacy(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Errorf("Registrar.GetWhoisPrivacy() returned error: %v", err)
 	}
@@ -57,7 +58,7 @@ func TestRegistrarService_EnableWhoisPrivacy(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	privacyResponse, err := client.Registrar.EnableWhoisPrivacy("1010", "example.com")
+	privacyResponse, err := client.Registrar.EnableWhoisPrivacy(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Errorf("Registrar.EnableWhoisPrivacy() returned error: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestRegistrarService_DisableWhoisPrivacy(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	privacyResponse, err := client.Registrar.DisableWhoisPrivacy("1010", "example.com")
+	privacyResponse, err := client.Registrar.DisableWhoisPrivacy(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Errorf("Registrar.DisableWhoisPrivacy() returned error: %v", err)
 	}
@@ -110,7 +111,7 @@ func TestRegistrarService_RenewWhoisPrivacy(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	privacyRenewalResponse, err := client.Registrar.RenewWhoisPrivacy("1010", "example.com")
+	privacyRenewalResponse, err := client.Registrar.RenewWhoisPrivacy(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Errorf("Registrar.RenewWhoisPrivacy() returned error: %v", err)
 	}

--- a/dnsimple/services.go
+++ b/dnsimple/services.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -68,7 +69,7 @@ func (s *ServicesService) ListServices(options *ListOptions) (*servicesResponse,
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, servicesResponse)
+	resp, err := s.client.get(context.TODO(), path, servicesResponse)
 	if err != nil {
 		return servicesResponse, err
 	}
@@ -84,7 +85,7 @@ func (s *ServicesService) GetService(serviceIdentifier string) (*serviceResponse
 	path := versioned(servicePath(serviceIdentifier))
 	serviceResponse := &serviceResponse{}
 
-	resp, err := s.client.get(path, serviceResponse)
+	resp, err := s.client.get(context.TODO(), path, serviceResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/services.go
+++ b/dnsimple/services.go
@@ -60,7 +60,7 @@ type ServicesResponse struct {
 // ListServices lists the one-click services available in DNSimple.
 //
 // See https://developer.dnsimple.com/v2/services/#list
-func (s *ServicesService) ListServices(options *ListOptions) (*ServicesResponse, error) {
+func (s *ServicesService) ListServices(ctx context.Context, options *ListOptions) (*ServicesResponse, error) {
 	path := versioned(servicePath(""))
 	servicesResponse := &ServicesResponse{}
 
@@ -69,7 +69,7 @@ func (s *ServicesService) ListServices(options *ListOptions) (*ServicesResponse,
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, servicesResponse)
+	resp, err := s.client.get(ctx, path, servicesResponse)
 	if err != nil {
 		return servicesResponse, err
 	}
@@ -81,11 +81,11 @@ func (s *ServicesService) ListServices(options *ListOptions) (*ServicesResponse,
 // GetService fetches a one-click service.
 //
 // See https://developer.dnsimple.com/v2/services/#get
-func (s *ServicesService) GetService(serviceIdentifier string) (*ServiceResponse, error) {
+func (s *ServicesService) GetService(ctx context.Context, serviceIdentifier string) (*ServiceResponse, error) {
 	path := versioned(servicePath(serviceIdentifier))
 	serviceResponse := &ServiceResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, serviceResponse)
+	resp, err := s.client.get(ctx, path, serviceResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -60,7 +61,7 @@ func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier str
 	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
 	serviceResponse := &serviceResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -29,7 +29,7 @@ func (s *ServicesService) AppliedServices(accountID string, domainIdentifier str
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, servicesResponse)
+	resp, err := s.client.get(context.TODO(), path, servicesResponse)
 	if err != nil {
 		return servicesResponse, err
 	}

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -20,7 +20,7 @@ type DomainServiceSettings struct {
 // AppliedServices lists the applied one-click services for a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#applied
-func (s *ServicesService) AppliedServices(accountID string, domainIdentifier string, options *ListOptions) (*ServicesResponse, error) {
+func (s *ServicesService) AppliedServices(ctx context.Context, accountID string, domainIdentifier string, options *ListOptions) (*ServicesResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainIdentifier, ""))
 	servicesResponse := &ServicesResponse{}
 
@@ -29,7 +29,7 @@ func (s *ServicesService) AppliedServices(accountID string, domainIdentifier str
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, servicesResponse)
+	resp, err := s.client.get(ctx, path, servicesResponse)
 	if err != nil {
 		return servicesResponse, err
 	}
@@ -41,11 +41,11 @@ func (s *ServicesService) AppliedServices(accountID string, domainIdentifier str
 // ApplyService applies a one-click services to a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#apply
-func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainIdentifier string, settings DomainServiceSettings) (*ServiceResponse, error) {
+func (s *ServicesService) ApplyService(ctx context.Context, accountID string, serviceIdentifier string, domainIdentifier string, settings DomainServiceSettings) (*ServiceResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
 	serviceResponse := &ServiceResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, settings, nil)
+	resp, err := s.client.post(ctx, path, settings, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -57,11 +57,11 @@ func (s *ServicesService) ApplyService(accountID string, serviceIdentifier strin
 // UnapplyService unapplies a one-click services from a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#unapply
-func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainIdentifier string) (*ServiceResponse, error) {
+func (s *ServicesService) UnapplyService(ctx context.Context, accountID string, serviceIdentifier string, domainIdentifier string) (*ServiceResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
 	serviceResponse := &ServiceResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -45,7 +45,7 @@ func (s *ServicesService) ApplyService(accountID string, serviceIdentifier strin
 	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
 	serviceResponse := &serviceResponse{}
 
-	resp, err := s.client.post(path, settings, nil)
+	resp, err := s.client.post(context.TODO(), path, settings, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/services_domains_test.go
+++ b/dnsimple/services_domains_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func TestServicesService_AppliedServices(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	servicesResponse, err := client.Services.AppliedServices("1010", "example.com", nil)
+	servicesResponse, err := client.Services.AppliedServices(context.Background(), "1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("DomainServices.AppliedServices() returned error: %v", err)
 	}
@@ -71,7 +72,7 @@ func TestServicesService_ApplyService(t *testing.T) {
 
 	settings := DomainServiceSettings{Settings: map[string]string{"app": "foo"}}
 
-	_, err := client.Services.ApplyService("1010", "service1", "example.com", settings)
+	_, err := client.Services.ApplyService(context.Background(), "1010", "service1", "example.com", settings)
 	if err != nil {
 		t.Fatalf("DomainServices.ApplyService() returned error: %v", err)
 	}
@@ -91,7 +92,7 @@ func TestServicesService_UnapplyService(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Services.UnapplyService("1010", "service1", "example.com")
+	_, err := client.Services.UnapplyService(context.Background(), "1010", "service1", "example.com")
 	if err != nil {
 		t.Fatalf("DomainServices.UnapplyService() returned error: %v", err)
 	}

--- a/dnsimple/services_test.go
+++ b/dnsimple/services_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func TestServicesService_List(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	servicesResponse, err := client.Services.ListServices(nil)
+	servicesResponse, err := client.Services.ListServices(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Services.ListServices() returned error: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestServicesService_List_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Services.ListServices(&ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Services.ListServices(context.Background(), &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Services.ListServices() returned error: %v", err)
 	}
@@ -90,7 +91,7 @@ func TestServicesService_Get(t *testing.T) {
 
 	serviceID := "1"
 
-	serviceResponse, err := client.Services.GetService(serviceID)
+	serviceResponse, err := client.Services.GetService(context.Background(), serviceID)
 	if err != nil {
 		t.Fatalf("Services.GetService() returned error: %v", err)
 	}

--- a/dnsimple/templates.go
+++ b/dnsimple/templates.go
@@ -104,7 +104,7 @@ func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier s
 	path := versioned(templatePath(accountID, templateIdentifier))
 	templateResponse := &templateResponse{}
 
-	resp, err := s.client.patch(path, templateAttributes, templateResponse)
+	resp, err := s.client.patch(context.TODO(), path, templateAttributes, templateResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates.go
+++ b/dnsimple/templates.go
@@ -72,7 +72,7 @@ func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes T
 	path := versioned(templatePath(accountID, ""))
 	templateResponse := &templateResponse{}
 
-	resp, err := s.client.post(path, templateAttributes, templateResponse)
+	resp, err := s.client.post(context.TODO(), path, templateAttributes, templateResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates.go
+++ b/dnsimple/templates.go
@@ -56,7 +56,7 @@ func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions)
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, templatesResponse)
+	resp, err := s.client.get(context.TODO(), path, templatesResponse)
 	if err != nil {
 		return templatesResponse, err
 	}
@@ -88,7 +88,7 @@ func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier stri
 	path := versioned(templatePath(accountID, templateIdentifier))
 	templateResponse := &templateResponse{}
 
-	resp, err := s.client.get(path, templateResponse)
+	resp, err := s.client.get(context.TODO(), path, templateResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates.go
+++ b/dnsimple/templates.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -119,7 +120,7 @@ func (s *TemplatesService) DeleteTemplate(accountID string, templateIdentifier s
 	path := versioned(templatePath(accountID, templateIdentifier))
 	templateResponse := &templateResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates.go
+++ b/dnsimple/templates.go
@@ -47,7 +47,7 @@ type TemplatesResponse struct {
 // ListTemplates list the templates for an account.
 //
 // See https://developer.dnsimple.com/v2/templates/#list
-func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions) (*TemplatesResponse, error) {
+func (s *TemplatesService) ListTemplates(ctx context.Context, accountID string, options *ListOptions) (*TemplatesResponse, error) {
 	path := versioned(templatePath(accountID, ""))
 	templatesResponse := &TemplatesResponse{}
 
@@ -56,7 +56,7 @@ func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions)
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, templatesResponse)
+	resp, err := s.client.get(ctx, path, templatesResponse)
 	if err != nil {
 		return templatesResponse, err
 	}
@@ -68,11 +68,11 @@ func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions)
 // CreateTemplate creates a new template.
 //
 // See https://developer.dnsimple.com/v2/templates/#create
-func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes Template) (*TemplateResponse, error) {
+func (s *TemplatesService) CreateTemplate(ctx context.Context, accountID string, templateAttributes Template) (*TemplateResponse, error) {
 	path := versioned(templatePath(accountID, ""))
 	templateResponse := &TemplateResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, templateAttributes, templateResponse)
+	resp, err := s.client.post(ctx, path, templateAttributes, templateResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +84,11 @@ func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes T
 // GetTemplate fetches a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#get
-func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier string) (*TemplateResponse, error) {
+func (s *TemplatesService) GetTemplate(ctx context.Context, accountID string, templateIdentifier string) (*TemplateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
 	templateResponse := &TemplateResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, templateResponse)
+	resp, err := s.client.get(ctx, path, templateResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -100,11 +100,11 @@ func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier stri
 // UpdateTemplate updates a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#update
-func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier string, templateAttributes Template) (*TemplateResponse, error) {
+func (s *TemplatesService) UpdateTemplate(ctx context.Context, accountID string, templateIdentifier string, templateAttributes Template) (*TemplateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
 	templateResponse := &TemplateResponse{}
 
-	resp, err := s.client.patch(context.TODO(), path, templateAttributes, templateResponse)
+	resp, err := s.client.patch(ctx, path, templateAttributes, templateResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -116,11 +116,11 @@ func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier s
 // DeleteTemplate deletes a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#delete
-func (s *TemplatesService) DeleteTemplate(accountID string, templateIdentifier string) (*TemplateResponse, error) {
+func (s *TemplatesService) DeleteTemplate(ctx context.Context, accountID string, templateIdentifier string) (*TemplateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
 	templateResponse := &TemplateResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates_domains.go
+++ b/dnsimple/templates_domains.go
@@ -7,12 +7,12 @@ import (
 
 // ApplyTemplate applies a template to the given domain.
 //
-// See https://developer.dnsimple.com/v2/templates/domains/#apply
-func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier string, domainIdentifier string) (*TemplateResponse, error) {
+// See https://developer.dnsimple.com/v2/templates/domains/#applyTemplateToDomain
+func (s *TemplatesService) ApplyTemplate(ctx context.Context, accountID string, templateIdentifier string, domainIdentifier string) (*TemplateResponse, error) {
 	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath(accountID, domainIdentifier), templateIdentifier))
 	templateResponse := &TemplateResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, nil, nil)
+	resp, err := s.client.post(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates_domains.go
+++ b/dnsimple/templates_domains.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -11,7 +12,7 @@ func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier st
 	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath(accountID, domainIdentifier), templateIdentifier))
 	templateResponse := &templateResponse{}
 
-	resp, err := s.client.post(path, nil, nil)
+	resp, err := s.client.post(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates_domains_test.go
+++ b/dnsimple/templates_domains_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -20,7 +21,7 @@ func TestTemplatesService_ApplyTemplate(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Templates.ApplyTemplate("1010", "1", "example.com")
+	_, err := client.Templates.ApplyTemplate(context.Background(), "1010", "1", "example.com")
 	if err != nil {
 		t.Fatalf("Templates.ApplyTemplate() returned error: %v", err)
 	}

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -50,7 +50,7 @@ func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentif
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, templateRecordsResponse)
+	resp, err := s.client.get(context.TODO(), path, templateRecordsResponse)
 	if err != nil {
 		return templateRecordsResponse, err
 	}
@@ -82,7 +82,7 @@ func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifie
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &templateRecordResponse{}
 
-	resp, err := s.client.get(path, templateRecordResponse)
+	resp, err := s.client.get(context.TODO(), path, templateRecordResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -41,7 +41,7 @@ type TemplateRecordsResponse struct {
 // ListTemplateRecords list the templates for an account.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#list
-func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentifier string, options *ListOptions) (*TemplateRecordsResponse, error) {
+func (s *TemplatesService) ListTemplateRecords(ctx context.Context, accountID string, templateIdentifier string, options *ListOptions) (*TemplateRecordsResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
 	templateRecordsResponse := &TemplateRecordsResponse{}
 
@@ -50,7 +50,7 @@ func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentif
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, templateRecordsResponse)
+	resp, err := s.client.get(ctx, path, templateRecordsResponse)
 	if err != nil {
 		return templateRecordsResponse, err
 	}
@@ -62,11 +62,11 @@ func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentif
 // CreateTemplateRecord creates a new template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#create
-func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*TemplateRecordResponse, error) {
+func (s *TemplatesService) CreateTemplateRecord(ctx context.Context, accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*TemplateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
 	templateRecordResponse := &TemplateRecordResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, templateRecordAttributes, templateRecordResponse)
+	resp, err := s.client.post(ctx, path, templateRecordAttributes, templateRecordResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -78,11 +78,11 @@ func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdenti
 // GetTemplateRecord fetches a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#get
-func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID int64) (*TemplateRecordResponse, error) {
+func (s *TemplatesService) GetTemplateRecord(ctx context.Context, accountID string, templateIdentifier string, templateRecordID int64) (*TemplateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &TemplateRecordResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, templateRecordResponse)
+	resp, err := s.client.get(ctx, path, templateRecordResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -94,11 +94,11 @@ func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifie
 // DeleteTemplateRecord deletes a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#delete
-func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID int64) (*TemplateRecordResponse, error) {
+func (s *TemplatesService) DeleteTemplateRecord(ctx context.Context, accountID string, templateIdentifier string, templateRecordID int64) (*TemplateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &TemplateRecordResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -66,7 +66,7 @@ func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdenti
 	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
 	templateRecordResponse := &templateRecordResponse{}
 
-	resp, err := s.client.post(path, templateRecordAttributes, templateRecordResponse)
+	resp, err := s.client.post(context.TODO(), path, templateRecordAttributes, templateRecordResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -97,7 +98,7 @@ func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdenti
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
 	templateRecordResponse := &templateRecordResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/templates_records_test.go
+++ b/dnsimple/templates_records_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func TestTemplatesService_ListTemplateRecords(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	templatesRecordsResponse, err := client.Templates.ListTemplateRecords("1010", "1", nil)
+	templatesRecordsResponse, err := client.Templates.ListTemplateRecords(context.Background(), "1010", "1", nil)
 	if err != nil {
 		t.Fatalf("Templates.ListTemplateRecords() returned error: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestTemplatesService_ListTemplateRecords_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Templates.ListTemplateRecords("1010", "1", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Templates.ListTemplateRecords(context.Background(), "1010", "1", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Templates.ListTemplateRecords() returned error: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestTemplatesService_CreateTemplateRecord(t *testing.T) {
 
 	templateRecordAttributes := TemplateRecord{Name: "Beta"}
 
-	templateRecordResponse, err := client.Templates.CreateTemplateRecord("1010", "1", templateRecordAttributes)
+	templateRecordResponse, err := client.Templates.CreateTemplateRecord(context.Background(), "1010", "1", templateRecordAttributes)
 	if err != nil {
 		t.Fatalf("Templates.CreateTemplateRecord() returned error: %v", err)
 	}
@@ -121,7 +122,7 @@ func TestTemplatesService_GetTemplateRecord(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	templateRecordResponse, err := client.Templates.GetTemplateRecord("1010", "1", 2)
+	templateRecordResponse, err := client.Templates.GetTemplateRecord(context.Background(), "1010", "1", 2)
 	if err != nil {
 		t.Fatalf("Templates.GetTemplateRecord() returned error: %v", err)
 	}
@@ -157,7 +158,7 @@ func TestTemplatesService_DeleteTemplateRecord(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Templates.DeleteTemplateRecord("1010", "1", 2)
+	_, err := client.Templates.DeleteTemplateRecord(context.Background(), "1010", "1", 2)
 	if err != nil {
 		t.Fatalf("Templates.DeleteTemplateRecord() returned error: %v", err)
 	}

--- a/dnsimple/templates_test.go
+++ b/dnsimple/templates_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func TestTemplatesService_List(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	templatesResponse, err := client.Templates.ListTemplates("1010", nil)
+	templatesResponse, err := client.Templates.ListTemplates(context.Background(), "1010", nil)
 	if err != nil {
 		t.Fatalf("Templates.ListTemplates() returned error: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestTemplatesService_List_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Templates.ListTemplates("1010", &ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Templates.ListTemplates(context.Background(), "1010", &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Templates.ListTemplates() returned error: %v", err)
 	}
@@ -94,7 +95,7 @@ func TestTemplatesService_Create(t *testing.T) {
 	accountID := "1010"
 	templateAttributes := Template{Name: "Beta"}
 
-	templateResponse, err := client.Templates.CreateTemplate(accountID, templateAttributes)
+	templateResponse, err := client.Templates.CreateTemplate(context.Background(), accountID, templateAttributes)
 	if err != nil {
 		t.Fatalf("Templates.CreateTemplate() returned error: %v", err)
 	}
@@ -122,7 +123,7 @@ func TestTemplatesService_Get(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	templateResponse, err := client.Templates.GetTemplate("1010", "1")
+	templateResponse, err := client.Templates.GetTemplate(context.Background(), "1010", "1")
 	if err != nil {
 		t.Fatalf("Templates.GetTemplate() returned error: %v", err)
 	}
@@ -157,7 +158,7 @@ func TestTemplatesService_UpdateTemplate(t *testing.T) {
 	})
 
 	templateAttributes := Template{Name: "Alpha"}
-	templateResponse, err := client.Templates.UpdateTemplate("1010", "1", templateAttributes)
+	templateResponse, err := client.Templates.UpdateTemplate(context.Background(), "1010", "1", templateAttributes)
 	if err != nil {
 		t.Fatalf("Templates.UpdateTemplate() returned error: %v", err)
 	}
@@ -191,7 +192,7 @@ func TestTemplatesService_DeleteTemplate(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Templates.DeleteTemplate("1010", "1")
+	_, err := client.Templates.DeleteTemplate(context.Background(), "1010", "1")
 	if err != nil {
 		t.Fatalf("Templates.DeleteTemplate() returned error: %v", err)
 	}

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -67,7 +67,7 @@ type TldExtendedAttributesResponse struct {
 // ListTlds lists the supported TLDs.
 //
 // See https://developer.dnsimple.com/v2/tlds/#list
-func (s *TldsService) ListTlds(options *ListOptions) (*TldsResponse, error) {
+func (s *TldsService) ListTlds(ctx context.Context, options *ListOptions) (*TldsResponse, error) {
 	path := versioned("/tlds")
 	tldsResponse := &TldsResponse{}
 
@@ -76,7 +76,7 @@ func (s *TldsService) ListTlds(options *ListOptions) (*TldsResponse, error) {
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, tldsResponse)
+	resp, err := s.client.get(ctx, path, tldsResponse)
 	if err != nil {
 		return tldsResponse, err
 	}
@@ -88,11 +88,11 @@ func (s *TldsService) ListTlds(options *ListOptions) (*TldsResponse, error) {
 // GetTld fetches a TLD.
 //
 // See https://developer.dnsimple.com/v2/tlds/#get
-func (s *TldsService) GetTld(tld string) (*TldResponse, error) {
+func (s *TldsService) GetTld(ctx context.Context, tld string) (*TldResponse, error) {
 	path := versioned(fmt.Sprintf("/tlds/%s", tld))
 	tldResponse := &TldResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, tldResponse)
+	resp, err := s.client.get(ctx, path, tldResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -104,11 +104,11 @@ func (s *TldsService) GetTld(tld string) (*TldResponse, error) {
 // GetTldExtendedAttributes fetches the extended attributes of a TLD.
 //
 // See https://developer.dnsimple.com/v2/tlds/#get
-func (s *TldsService) GetTldExtendedAttributes(tld string) (*TldExtendedAttributesResponse, error) {
+func (s *TldsService) GetTldExtendedAttributes(ctx context.Context, tld string) (*TldExtendedAttributesResponse, error) {
 	path := versioned(fmt.Sprintf("/tlds/%s/extended_attributes", tld))
 	tldResponse := &TldExtendedAttributesResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, tldResponse)
+	resp, err := s.client.get(ctx, path, tldResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -75,7 +76,7 @@ func (s *TldsService) ListTlds(options *ListOptions) (*tldsResponse, error) {
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, tldsResponse)
+	resp, err := s.client.get(context.TODO(), path, tldsResponse)
 	if err != nil {
 		return tldsResponse, err
 	}
@@ -91,7 +92,7 @@ func (s *TldsService) GetTld(tld string) (*tldResponse, error) {
 	path := versioned(fmt.Sprintf("/tlds/%s", tld))
 	tldResponse := &tldResponse{}
 
-	resp, err := s.client.get(path, tldResponse)
+	resp, err := s.client.get(context.TODO(), path, tldResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (s *TldsService) GetTldExtendedAttributes(tld string) (*tldExtendedAttribut
 	path := versioned(fmt.Sprintf("/tlds/%s/extended_attributes", tld))
 	tldResponse := &tldExtendedAttributesResponse{}
 
-	resp, err := s.client.get(path, tldResponse)
+	resp, err := s.client.get(context.TODO(), path, tldResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/tlds_test.go
+++ b/dnsimple/tlds_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,7 +23,7 @@ func TestTldsService_ListTlds(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	tldsResponse, err := client.Tlds.ListTlds(nil)
+	tldsResponse, err := client.Tlds.ListTlds(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Tlds.ListTlds() returned error: %v", err)
 	}
@@ -70,7 +71,7 @@ func TestTldsService_ListTlds_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Tlds.ListTlds(&ListOptions{Page: 2, PerPage: 20})
+	_, err := client.Tlds.ListTlds(context.Background(), &ListOptions{Page: 2, PerPage: 20})
 	if err != nil {
 		t.Fatalf("Tlds.ListTlds() returned error: %v", err)
 	}
@@ -90,7 +91,7 @@ func TestTldsService_GetTld(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	tldResponse, err := client.Tlds.GetTld("com")
+	tldResponse, err := client.Tlds.GetTld(context.Background(), "com")
 	if err != nil {
 		t.Fatalf("Tlds.GetTlds() returned error: %v", err)
 	}
@@ -118,7 +119,7 @@ func TestTldsService_GetTldExtendedAttributes(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	tldResponse, err := client.Tlds.GetTldExtendedAttributes("com")
+	tldResponse, err := client.Tlds.GetTldExtendedAttributes(context.Background(), "com")
 	if err != nil {
 		t.Fatalf("Tlds.GetTldExtendedAttributes() returned error: %v", err)
 	}

--- a/dnsimple/vanity_name_server.go
+++ b/dnsimple/vanity_name_server.go
@@ -40,7 +40,7 @@ func (s *VanityNameServersService) EnableVanityNameServers(accountID string, dom
 	path := versioned(vanityNameServerPath(accountID, domainIdentifier))
 	vanityNameServerResponse := &vanityNameServerResponse{}
 
-	resp, err := s.client.put(path, nil, vanityNameServerResponse)
+	resp, err := s.client.put(context.TODO(), path, nil, vanityNameServerResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/vanity_name_server.go
+++ b/dnsimple/vanity_name_server.go
@@ -35,12 +35,12 @@ type VanityNameServerResponse struct {
 
 // EnableVanityNameServers Vanity Name Servers for the given domain
 //
-// See https://developer.dnsimple.com/v2/vanity/#enable
-func (s *VanityNameServersService) EnableVanityNameServers(accountID string, domainIdentifier string) (*VanityNameServerResponse, error) {
+// See https://developer.dnsimple.com/v2/vanity/#enableVanityNameServers
+func (s *VanityNameServersService) EnableVanityNameServers(ctx context.Context, accountID string, domainIdentifier string) (*VanityNameServerResponse, error) {
 	path := versioned(vanityNameServerPath(accountID, domainIdentifier))
 	vanityNameServerResponse := &VanityNameServerResponse{}
 
-	resp, err := s.client.put(context.TODO(), path, nil, vanityNameServerResponse)
+	resp, err := s.client.put(ctx, path, nil, vanityNameServerResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -51,12 +51,12 @@ func (s *VanityNameServersService) EnableVanityNameServers(accountID string, dom
 
 // DisableVanityNameServers Vanity Name Servers for the given domain
 //
-// See https://developer.dnsimple.com/v2/vanity/#disable
-func (s *VanityNameServersService) DisableVanityNameServers(accountID string, domainIdentifier string) (*VanityNameServerResponse, error) {
+// See https://developer.dnsimple.com/v2/vanity/#disableVanityNameServers
+func (s *VanityNameServersService) DisableVanityNameServers(ctx context.Context, accountID string, domainIdentifier string) (*VanityNameServerResponse, error) {
 	path := versioned(vanityNameServerPath(accountID, domainIdentifier))
 	vanityNameServerResponse := &VanityNameServerResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/vanity_name_server.go
+++ b/dnsimple/vanity_name_server.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -55,7 +56,7 @@ func (s *VanityNameServersService) DisableVanityNameServers(accountID string, do
 	path := versioned(vanityNameServerPath(accountID, domainIdentifier))
 	vanityNameServerResponse := &vanityNameServerResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/vanity_name_servers_test.go
+++ b/dnsimple/vanity_name_servers_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -26,7 +27,7 @@ func TestVanityNameServersService_EnableVanityNameServers(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	vanityNameServerResponse, err := client.VanityNameServers.EnableVanityNameServers("1010", "example.com")
+	vanityNameServerResponse, err := client.VanityNameServers.EnableVanityNameServers(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Fatalf("VanityNameServers.EnableVanityNameServers() returned error: %v", err)
 	}
@@ -53,7 +54,7 @@ func TestVanityNameServersService_DisableVanityNameServers(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.VanityNameServers.DisableVanityNameServers("1010", "example.com")
+	_, err := client.VanityNameServers.DisableVanityNameServers(context.Background(), "1010", "example.com")
 	if err != nil {
 		t.Fatalf("VanityNameServers.DisableVanityNameServers() returned error: %v", err)
 	}

--- a/dnsimple/webhooks.go
+++ b/dnsimple/webhooks.go
@@ -42,11 +42,11 @@ type WebhooksResponse struct {
 // ListWebhooks lists the webhooks for an account.
 //
 // See https://developer.dnsimple.com/v2/webhooks#list
-func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*WebhooksResponse, error) {
+func (s *WebhooksService) ListWebhooks(ctx context.Context, accountID string, _ *ListOptions) (*WebhooksResponse, error) {
 	path := versioned(webhookPath(accountID, 0))
 	webhooksResponse := &WebhooksResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, webhooksResponse)
+	resp, err := s.client.get(ctx, path, webhooksResponse)
 	if err != nil {
 		return webhooksResponse, err
 	}
@@ -58,11 +58,11 @@ func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*Webho
 // CreateWebhook creates a new webhook.
 //
 // See https://developer.dnsimple.com/v2/webhooks#create
-func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webhook) (*WebhookResponse, error) {
+func (s *WebhooksService) CreateWebhook(ctx context.Context, accountID string, webhookAttributes Webhook) (*WebhookResponse, error) {
 	path := versioned(webhookPath(accountID, 0))
 	webhookResponse := &WebhookResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, webhookAttributes, webhookResponse)
+	resp, err := s.client.post(ctx, path, webhookAttributes, webhookResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -74,11 +74,11 @@ func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webh
 // GetWebhook fetches a webhook.
 //
 // See https://developer.dnsimple.com/v2/webhooks#get
-func (s *WebhooksService) GetWebhook(accountID string, webhookID int64) (*WebhookResponse, error) {
+func (s *WebhooksService) GetWebhook(ctx context.Context, accountID string, webhookID int64) (*WebhookResponse, error) {
 	path := versioned(webhookPath(accountID, webhookID))
 	webhookResponse := &WebhookResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, webhookResponse)
+	resp, err := s.client.get(ctx, path, webhookResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -90,11 +90,11 @@ func (s *WebhooksService) GetWebhook(accountID string, webhookID int64) (*Webhoo
 // DeleteWebhook PERMANENTLY deletes a webhook from the account.
 //
 // See https://developer.dnsimple.com/v2/webhooks#delete
-func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int64) (*WebhookResponse, error) {
+func (s *WebhooksService) DeleteWebhook(ctx context.Context, accountID string, webhookID int64) (*WebhookResponse, error) {
 	path := versioned(webhookPath(accountID, webhookID))
 	webhookResponse := &WebhookResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/webhooks.go
+++ b/dnsimple/webhooks.go
@@ -46,7 +46,7 @@ func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*webho
 	path := versioned(webhookPath(accountID, 0))
 	webhooksResponse := &webhooksResponse{}
 
-	resp, err := s.client.get(path, webhooksResponse)
+	resp, err := s.client.get(context.TODO(), path, webhooksResponse)
 	if err != nil {
 		return webhooksResponse, err
 	}
@@ -78,7 +78,7 @@ func (s *WebhooksService) GetWebhook(accountID string, webhookID int64) (*webhoo
 	path := versioned(webhookPath(accountID, webhookID))
 	webhookResponse := &webhookResponse{}
 
-	resp, err := s.client.get(path, webhookResponse)
+	resp, err := s.client.get(context.TODO(), path, webhookResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/webhooks.go
+++ b/dnsimple/webhooks.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -93,7 +94,7 @@ func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int64) (*web
 	path := versioned(webhookPath(accountID, webhookID))
 	webhookResponse := &webhookResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/webhooks.go
+++ b/dnsimple/webhooks.go
@@ -62,7 +62,7 @@ func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webh
 	path := versioned(webhookPath(accountID, 0))
 	webhookResponse := &webhookResponse{}
 
-	resp, err := s.client.post(path, webhookAttributes, webhookResponse)
+	resp, err := s.client.post(context.TODO(), path, webhookAttributes, webhookResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/webhooks_test.go
+++ b/dnsimple/webhooks_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"reflect"
@@ -31,7 +32,7 @@ func TestWebhooksService_ListWebhooks(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	webhooksResponse, err := client.Webhooks.ListWebhooks("1010", nil)
+	webhooksResponse, err := client.Webhooks.ListWebhooks(context.Background(), "1010", nil)
 	if err != nil {
 		t.Fatalf("Webhooks.List() returned error: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestWebhooksService_CreateWebhook(t *testing.T) {
 
 	webhookAttributes := Webhook{URL: "https://webhook.test"}
 
-	webhookResponse, err := client.Webhooks.CreateWebhook("1010", webhookAttributes)
+	webhookResponse, err := client.Webhooks.CreateWebhook(context.Background(), "1010", webhookAttributes)
 	if err != nil {
 		t.Fatalf("Webhooks.Create() returned error: %v", err)
 	}
@@ -96,7 +97,7 @@ func TestWebhooksService_GetWebhook(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	webhookResponse, err := client.Webhooks.GetWebhook("1010", 1)
+	webhookResponse, err := client.Webhooks.GetWebhook(context.Background(), "1010", 1)
 	if err != nil {
 		t.Fatalf("Webhooks.Get() returned error: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestWebhooksService_DeleteWebhook(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Webhooks.DeleteWebhook("1010", 1)
+	_, err := client.Webhooks.DeleteWebhook(context.Background(), "1010", 1)
 	if err != nil {
 		t.Fatalf("Webhooks.Delete() returned error: %v", err)
 	}

--- a/dnsimple/zone_distributions.go
+++ b/dnsimple/zone_distributions.go
@@ -1,6 +1,9 @@
 package dnsimple
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // ZoneDistribution is the result of the zone distribution check.
 type ZoneDistribution struct {
@@ -20,7 +23,7 @@ func (s *ZonesService) CheckZoneDistribution(accountID string, zoneName string) 
 	path := versioned(fmt.Sprintf("/%v/zones/%v/distribution", accountID, zoneName))
 	zoneDistributionResponse := &zoneDistributionResponse{}
 
-	resp, err := s.client.get(path, zoneDistributionResponse)
+	resp, err := s.client.get(context.TODO(), path, zoneDistributionResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +39,7 @@ func (s *ZonesService) CheckZoneRecordDistribution(accountID string, zoneName st
 	path := versioned(fmt.Sprintf("/%v/zones/%v/records/%v/distribution", accountID, zoneName, recordID))
 	zoneDistributionResponse := &zoneDistributionResponse{}
 
-	resp, err := s.client.get(path, zoneDistributionResponse)
+	resp, err := s.client.get(context.TODO(), path, zoneDistributionResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/zone_distributions.go
+++ b/dnsimple/zone_distributions.go
@@ -19,11 +19,11 @@ type ZoneDistributionResponse struct {
 // CheckZoneDistribution checks if a zone is fully distributed across DNSimple nodes.
 //
 // See https://developer.dnsimple.com/v2/zones/#checkZoneDistribution
-func (s *ZonesService) CheckZoneDistribution(accountID string, zoneName string) (*ZoneDistributionResponse, error) {
+func (s *ZonesService) CheckZoneDistribution(ctx context.Context, accountID string, zoneName string) (*ZoneDistributionResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v/distribution", accountID, zoneName))
 	zoneDistributionResponse := &ZoneDistributionResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, zoneDistributionResponse)
+	resp, err := s.client.get(ctx, path, zoneDistributionResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -35,11 +35,11 @@ func (s *ZonesService) CheckZoneDistribution(accountID string, zoneName string) 
 // CheckZoneRecordDistribution checks if a zone is fully distributed across DNSimple nodes.
 //
 // See https://developer.dnsimple.com/v2/zones/#checkZoneRecordDistribution
-func (s *ZonesService) CheckZoneRecordDistribution(accountID string, zoneName string, recordID int64) (*ZoneDistributionResponse, error) {
+func (s *ZonesService) CheckZoneRecordDistribution(ctx context.Context, accountID string, zoneName string, recordID int64) (*ZoneDistributionResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v/records/%v/distribution", accountID, zoneName, recordID))
 	zoneDistributionResponse := &ZoneDistributionResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, zoneDistributionResponse)
+	resp, err := s.client.get(ctx, path, zoneDistributionResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -66,7 +67,7 @@ func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*z
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, zonesResponse)
+	resp, err := s.client.get(context.TODO(), path, zonesResponse)
 	if err != nil {
 		return zonesResponse, err
 	}
@@ -82,7 +83,7 @@ func (s *ZonesService) GetZone(accountID string, zoneName string) (*zoneResponse
 	path := versioned(fmt.Sprintf("/%v/zones/%v", accountID, zoneName))
 	zoneResponse := &zoneResponse{}
 
-	resp, err := s.client.get(path, zoneResponse)
+	resp, err := s.client.get(context.TODO(), path, zoneResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (s *ZonesService) GetZoneFile(accountID string, zoneName string) (*zoneFile
 	path := versioned(fmt.Sprintf("/%v/zones/%v/file", accountID, zoneName))
 	zoneFileResponse := &zoneFileResponse{}
 
-	resp, err := s.client.get(path, zoneFileResponse)
+	resp, err := s.client.get(context.TODO(), path, zoneFileResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -57,8 +57,8 @@ type ZoneListOptions struct {
 
 // ListZones the zones for an account.
 //
-// See https://developer.dnsimple.com/v2/zones/#list
-func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*ZonesResponse, error) {
+// See https://developer.dnsimple.com/v2/zones/#listZones
+func (s *ZonesService) ListZones(ctx context.Context, accountID string, options *ZoneListOptions) (*ZonesResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones", accountID))
 	zonesResponse := &ZonesResponse{}
 
@@ -67,7 +67,7 @@ func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*Z
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, zonesResponse)
+	resp, err := s.client.get(ctx, path, zonesResponse)
 	if err != nil {
 		return zonesResponse, err
 	}
@@ -78,12 +78,12 @@ func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*Z
 
 // GetZone fetches a zone.
 //
-// See https://developer.dnsimple.com/v2/zones/#get
-func (s *ZonesService) GetZone(accountID string, zoneName string) (*ZoneResponse, error) {
+// See https://developer.dnsimple.com/v2/zones/#getZone
+func (s *ZonesService) GetZone(ctx context.Context, accountID string, zoneName string) (*ZoneResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v", accountID, zoneName))
 	zoneResponse := &ZoneResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, zoneResponse)
+	resp, err := s.client.get(ctx, path, zoneResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -94,12 +94,12 @@ func (s *ZonesService) GetZone(accountID string, zoneName string) (*ZoneResponse
 
 // GetZoneFile fetches a zone file.
 //
-// See https://developer.dnsimple.com/v2/zones/#get-file
-func (s *ZonesService) GetZoneFile(accountID string, zoneName string) (*ZoneFileResponse, error) {
+// See https://developer.dnsimple.com/v2/zones/#getZoneFile
+func (s *ZonesService) GetZoneFile(ctx context.Context, accountID string, zoneName string) (*ZoneFileResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v/file", accountID, zoneName))
 	zoneFileResponse := &ZoneFileResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, zoneFileResponse)
+	resp, err := s.client.get(ctx, path, zoneFileResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/zones_distributions_test.go
+++ b/dnsimple/zones_distributions_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"reflect"
@@ -24,7 +25,7 @@ func TestZonesService_CheckZoneDistribution(t *testing.T) {
 	accountID := "1010"
 	zoneName := "example.com"
 
-	zoneDistributionResponse, err := client.Zones.CheckZoneDistribution(accountID, zoneName)
+	zoneDistributionResponse, err := client.Zones.CheckZoneDistribution(context.Background(), accountID, zoneName)
 	if err != nil {
 		t.Fatalf("Zones.CheckZoneDistribution() returned error: %v", err)
 	}
@@ -56,7 +57,7 @@ func TestZonesService_CheckZoneDistributionFailure(t *testing.T) {
 	accountID := "1010"
 	zoneName := "example.com"
 
-	zoneDistributionResponse, err := client.Zones.CheckZoneDistribution(accountID, zoneName)
+	zoneDistributionResponse, err := client.Zones.CheckZoneDistribution(context.Background(), accountID, zoneName)
 	if err != nil {
 		t.Fatalf("Zones.CheckZoneDistribution() returned error: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestZonesService_CheckZoneDistributionError(t *testing.T) {
 	accountID := "1010"
 	zoneName := "example.com"
 
-	zoneDistributionResponse, err := client.Zones.CheckZoneDistribution(accountID, zoneName)
+	zoneDistributionResponse, err := client.Zones.CheckZoneDistribution(context.Background(), accountID, zoneName)
 	if err == nil {
 		t.Fatalf("Zones.CheckZoneDistribution() expected to return an error: %v", zoneDistributionResponse)
 	}
@@ -116,7 +117,7 @@ func TestZonesService_CheckZoneRecordDistribution(t *testing.T) {
 	zoneName := "example.com"
 	recordID := int64(1)
 
-	zoneDistributionResponse, err := client.Zones.CheckZoneRecordDistribution(accountID, zoneName, recordID)
+	zoneDistributionResponse, err := client.Zones.CheckZoneRecordDistribution(context.Background(), accountID, zoneName, recordID)
 	if err != nil {
 		t.Fatalf("Zones.CheckZoneRecordDistribution() returned error: %v", err)
 	}
@@ -149,7 +150,7 @@ func TestZonesService_CheckZoneRecordDistributionFailure(t *testing.T) {
 	zoneName := "example.com"
 	recordID := int64(1)
 
-	zoneDistributionResponse, err := client.Zones.CheckZoneRecordDistribution(accountID, zoneName, recordID)
+	zoneDistributionResponse, err := client.Zones.CheckZoneRecordDistribution(context.Background(), accountID, zoneName, recordID)
 	if err != nil {
 		t.Fatalf("Zones.CheckZoneRecordDistribution() returned error: %v", err)
 	}
@@ -182,7 +183,7 @@ func TestZonesService_CheckZoneRecordDistributionError(t *testing.T) {
 	zoneName := "example.com"
 	recordID := int64(1)
 
-	zoneDistributionResponse, err := client.Zones.CheckZoneRecordDistribution(accountID, zoneName, recordID)
+	zoneDistributionResponse, err := client.Zones.CheckZoneRecordDistribution(context.Background(), accountID, zoneName, recordID)
 	if err == nil {
 		t.Fatalf("Zones.CheckZoneRecordDistribution() expected to return an error: %v", zoneDistributionResponse)
 	}

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -69,7 +69,7 @@ func (s *ZonesService) ListRecords(accountID string, zoneName string, options *Z
 		return nil, err
 	}
 
-	resp, err := s.client.get(path, recordsResponse)
+	resp, err := s.client.get(context.TODO(), path, recordsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 
-	resp, err := s.client.get(path, recordResponse)
+	resp, err := s.client.get(context.TODO(), path, recordResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -85,7 +85,7 @@ func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAtt
 	path := versioned(zoneRecordPath(accountID, zoneName, 0))
 	recordResponse := &zoneRecordResponse{}
 
-	resp, err := s.client.post(path, recordAttributes, recordResponse)
+	resp, err := s.client.post(context.TODO(), path, recordAttributes, recordResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -60,7 +60,7 @@ type ZoneRecordListOptions struct {
 // ListRecords lists the zone records for a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#listZoneRecords
-func (s *ZonesService) ListRecords(accountID string, zoneName string, options *ZoneRecordListOptions) (*ZoneRecordsResponse, error) {
+func (s *ZonesService) ListRecords(ctx context.Context, accountID string, zoneName string, options *ZoneRecordListOptions) (*ZoneRecordsResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, 0))
 	recordsResponse := &ZoneRecordsResponse{}
 
@@ -69,7 +69,7 @@ func (s *ZonesService) ListRecords(accountID string, zoneName string, options *Z
 		return nil, err
 	}
 
-	resp, err := s.client.get(context.TODO(), path, recordsResponse)
+	resp, err := s.client.get(ctx, path, recordsResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -81,11 +81,11 @@ func (s *ZonesService) ListRecords(accountID string, zoneName string, options *Z
 // CreateRecord creates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#createZoneRecord
-func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
+func (s *ZonesService) CreateRecord(ctx context.Context, accountID string, zoneName string, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, 0))
 	recordResponse := &ZoneRecordResponse{}
 
-	resp, err := s.client.post(context.TODO(), path, recordAttributes, recordResponse)
+	resp, err := s.client.post(ctx, path, recordAttributes, recordResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -97,11 +97,11 @@ func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAtt
 // GetRecord fetches a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#getZoneRecord
-func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int64) (*ZoneRecordResponse, error) {
+func (s *ZonesService) GetRecord(ctx context.Context, accountID string, zoneName string, recordID int64) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &ZoneRecordResponse{}
 
-	resp, err := s.client.get(context.TODO(), path, recordResponse)
+	resp, err := s.client.get(ctx, path, recordResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -113,10 +113,10 @@ func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int
 // UpdateRecord updates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#updateZoneRecord
-func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID int64, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
+func (s *ZonesService) UpdateRecord(ctx context.Context, accountID string, zoneName string, recordID int64, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &ZoneRecordResponse{}
-	resp, err := s.client.patch(context.TODO(), path, recordAttributes, recordResponse)
+	resp, err := s.client.patch(ctx, path, recordAttributes, recordResponse)
 
 	if err != nil {
 		return nil, err
@@ -129,11 +129,11 @@ func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID 
 // DeleteRecord PERMANENTLY deletes a zone record from the zone.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#deleteZoneRecord
-func (s *ZonesService) DeleteRecord(accountID string, zoneName string, recordID int64) (*ZoneRecordResponse, error) {
+func (s *ZonesService) DeleteRecord(ctx context.Context, accountID string, zoneName string, recordID int64) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &ZoneRecordResponse{}
 
-	resp, err := s.client.delete(context.TODO(), path, nil, nil)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -132,7 +133,7 @@ func (s *ZonesService) DeleteRecord(accountID string, zoneName string, recordID 
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
 
-	resp, err := s.client.delete(path, nil, nil)
+	resp, err := s.client.delete(context.TODO(), path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -116,7 +116,7 @@ func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int
 func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID int64, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &zoneRecordResponse{}
-	resp, err := s.client.patch(path, recordAttributes, recordResponse)
+	resp, err := s.client.patch(context.TODO(), path, recordAttributes, recordResponse)
 
 	if err != nil {
 		return nil, err

--- a/dnsimple/zones_records_test.go
+++ b/dnsimple/zones_records_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -32,7 +33,7 @@ func TestZonesService_ListRecords(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	recordsResponse, err := client.Zones.ListRecords("1010", "example.com", nil)
+	recordsResponse, err := client.Zones.ListRecords(context.Background(), "1010", "example.com", nil)
 	if err != nil {
 		t.Fatalf("Zones.ListRecords() returned error: %v", err)
 	}
@@ -77,7 +78,7 @@ func TestZonesService_ListRecords_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Zones.ListRecords("1010", "example.com", &ZoneRecordListOptions{"example", "www", "A", ListOptions{Page: 2, PerPage: 20, Sort: "name,expiration:desc"}})
+	_, err := client.Zones.ListRecords(context.Background(), "1010", "example.com", &ZoneRecordListOptions{"example", "www", "A", ListOptions{Page: 2, PerPage: 20, Sort: "name,expiration:desc"}})
 	if err != nil {
 		t.Fatalf("Zones.ListRecords() returned error: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestZonesService_CreateRecord(t *testing.T) {
 	accountID := "1010"
 	recordValues := ZoneRecord{Name: "foo", Content: "mxa.example.com", Type: "MX"}
 
-	recordResponse, err := client.Zones.CreateRecord(accountID, "example.com", recordValues)
+	recordResponse, err := client.Zones.CreateRecord(context.Background(), accountID, "example.com", recordValues)
 	if err != nil {
 		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
 	}
@@ -142,7 +143,7 @@ func TestZonesService_CreateRecord_BlankName(t *testing.T) {
 
 	recordValues := ZoneRecord{Name: "", Content: "127.0.0.1", Type: "A"}
 
-	recordResponse, err := client.Zones.CreateRecord("1010", "example.com", recordValues)
+	recordResponse, err := client.Zones.CreateRecord(context.Background(), "1010", "example.com", recordValues)
 	if err != nil {
 		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
 	}
@@ -173,7 +174,7 @@ func TestZonesService_CreateRecord_Regions(t *testing.T) {
 	})
 
 	recordValues = ZoneRecord{Name: "foo", Regions: []string{}}
-	if _, err := client.Zones.CreateRecord("1", "example.com", recordValues); err != nil {
+	if _, err := client.Zones.CreateRecord(context.Background(), "1", "example.com", recordValues); err != nil {
 		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
 	}
 
@@ -188,7 +189,7 @@ func TestZonesService_CreateRecord_Regions(t *testing.T) {
 	})
 
 	recordValues = ZoneRecord{Name: "foo", Regions: []string{"global"}}
-	if _, err := client.Zones.CreateRecord("2", "example.com", recordValues); err != nil {
+	if _, err := client.Zones.CreateRecord(context.Background(), "2", "example.com", recordValues); err != nil {
 		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
 	}
 
@@ -203,7 +204,7 @@ func TestZonesService_CreateRecord_Regions(t *testing.T) {
 	})
 
 	recordValues = ZoneRecord{Name: "foo", Regions: []string{"global"}}
-	if _, err := client.Zones.CreateRecord("2", "example.com", recordValues); err != nil {
+	if _, err := client.Zones.CreateRecord(context.Background(), "2", "example.com", recordValues); err != nil {
 		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
 	}
 }
@@ -224,7 +225,7 @@ func TestZonesService_GetRecord(t *testing.T) {
 
 	accountID := "1010"
 
-	recordResponse, err := client.Zones.GetRecord(accountID, "example.com", 1539)
+	recordResponse, err := client.Zones.GetRecord(context.Background(), accountID, "example.com", 1539)
 	if err != nil {
 		t.Fatalf("Zones.GetRecord() returned error: %v", err)
 	}
@@ -269,7 +270,7 @@ func TestZonesService_UpdateRecord(t *testing.T) {
 	accountID := "1010"
 	recordValues := ZoneRecord{Name: "foo", Content: "127.0.0.1"}
 
-	recordResponse, err := client.Zones.UpdateRecord(accountID, "example.com", 5, recordValues)
+	recordResponse, err := client.Zones.UpdateRecord(context.Background(), accountID, "example.com", 5, recordValues)
 	if err != nil {
 		t.Fatalf("Zones.UpdateRecord() returned error: %v", err)
 	}
@@ -300,7 +301,7 @@ func TestZonesService_UpdateRecord_Regions(t *testing.T) {
 	})
 
 	recordValues = ZoneRecord{Name: "foo", Regions: []string{}}
-	if _, err := client.Zones.UpdateRecord("1", "example.com", 1, recordValues); err != nil {
+	if _, err := client.Zones.UpdateRecord(context.Background(), "1", "example.com", 1, recordValues); err != nil {
 		t.Fatalf("Zones.UpdateRecord() returned error: %v", err)
 	}
 
@@ -315,7 +316,7 @@ func TestZonesService_UpdateRecord_Regions(t *testing.T) {
 	})
 
 	recordValues = ZoneRecord{Name: "foo", Regions: []string{"global"}}
-	if _, err := client.Zones.UpdateRecord("2", "example.com", 1, recordValues); err != nil {
+	if _, err := client.Zones.UpdateRecord(context.Background(), "2", "example.com", 1, recordValues); err != nil {
 		t.Fatalf("Zones.UpdateRecord() returned error: %v", err)
 	}
 
@@ -330,7 +331,7 @@ func TestZonesService_UpdateRecord_Regions(t *testing.T) {
 	})
 
 	recordValues = ZoneRecord{Name: "foo", Regions: []string{"global"}}
-	if _, err := client.Zones.UpdateRecord("2", "example.com", 1, recordValues); err != nil {
+	if _, err := client.Zones.UpdateRecord(context.Background(), "2", "example.com", 1, recordValues); err != nil {
 		t.Fatalf("Zones.UpdateRecord() returned error: %v", err)
 	}
 }
@@ -351,7 +352,7 @@ func TestZonesService_DeleteRecord(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Zones.DeleteRecord(accountID, "example.com", 2)
+	_, err := client.Zones.DeleteRecord(context.Background(), accountID, "example.com", 2)
 	if err != nil {
 		t.Fatalf("Zones.DeleteRecord() returned error: %v", err)
 	}

--- a/dnsimple/zones_test.go
+++ b/dnsimple/zones_test.go
@@ -1,6 +1,7 @@
 package dnsimple
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,7 +23,7 @@ func TestZonesService_ListZones(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	zonesResponse, err := client.Zones.ListZones("1010", nil)
+	zonesResponse, err := client.Zones.ListZones(context.Background(), "1010", nil)
 	if err != nil {
 		t.Fatalf("Zones.ListZones() returned error: %v", err)
 	}
@@ -62,7 +63,7 @@ func TestZonesService_ListZones_WithOptions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	_, err := client.Zones.ListZones("1010", &ZoneListOptions{"example", ListOptions{Page: 2, PerPage: 20, Sort: "name,expiration:desc"}})
+	_, err := client.Zones.ListZones(context.Background(), "1010", &ZoneListOptions{"example", ListOptions{Page: 2, PerPage: 20, Sort: "name,expiration:desc"}})
 	if err != nil {
 		t.Fatalf("Zones.ListZones() returned error: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestZonesService_GetZone(t *testing.T) {
 	accountID := "1010"
 	zoneName := "example.com"
 
-	zoneResponse, err := client.Zones.GetZone(accountID, zoneName)
+	zoneResponse, err := client.Zones.GetZone(context.Background(), accountID, zoneName)
 	if err != nil {
 		t.Fatalf("Zones.GetZone() returned error: %v", err)
 	}
@@ -121,7 +122,7 @@ func TestZonesService_GetZoneFile(t *testing.T) {
 	accountID := "1010"
 	zoneName := "example.com"
 
-	zoneFileResponse, err := client.Zones.GetZoneFile(accountID, zoneName)
+	zoneFileResponse, err := client.Zones.GetZoneFile(context.Background(), accountID, zoneName)
 	if err != nil {
 		t.Fatalf("Zones.GetZoneFile() returned error: %v", err)
 	}


### PR DESCRIPTION
This PR is an initial effort to introduce [Go contexts](https://blog.golang.org/context).

This is something I've been planning for quite a long time. An initial request along with a great PR was provided in https://github.com/dnsimple/dnsimple-go/pull/82.

I went back and forth about the idea of merging #82 vs making more structural changes. The main benefit of #82 were:

- reduced impact on the current codebase
- no need to change current methods signature

The downside were mostly two, related to performances and long-term maintainability:

- The context is assigned (and stored) into the client, which requires to create copies of the client to use different contexts
- I'm seeing all clients moving towards per-request signatures, so in the long run this seems to be the direction.

Given that we're not 1.0 yet, I decided to give it a try to use per-request contexts. As mentioned, this is what most clients are moving towards, at least by looking at some quite relevant Go SDKs.

For instance, [Cloudflare client is using contexts in new functions](https://github.com/cloudflare/cloudflare-go/commit/f1215c4edce10463d3b60c9fd8b9a6dfa4f0685a). Interestingly, they also have several context-specific methods like [`ListZonesContext`](https://github.com/cloudflare/cloudflare-go/blob/b08349a5c3e7b0d785660cd2b29875f806f88a2b/zone.go#L429), probably because they have to support both for legacy purposes. That's what I'd like to avoid long terms by eating the bullet sooner rather than later.

Another client that I often observe is github-go, which had some notable influence to our clients. They made a drastic switch https://github.com/google/go-github/commit/23d6cb9cacb5aa314e93d600fe20a48496a718d4 and they call it done. Same story, they went for per-function context.

So here's the changes I made in this PR:

1. `NewRequest` and `Do` are now not exported. This ensures we are free to move things internally without affecting customers outside. I originally kept these names public as I was inspired by go-github, but also because I used them as helpers to test not implemented methods in the context of the client. So I decided to provide a more high level `Request` method that can be used for this purpose, without allowing anymore to interact with the low-level client internals anymore.
2. I kept `newRequest` and `Do -> request` around to segment the request preparation. It made it easier to test it, also it required minimum changes in our test suite.
3. I'm propagating the context all the way to the final functions, and at that point I'll see if making them available in the signature or (alternatively) we can also preserve the per-client idea proposed in #82.
