### PR TITLE
Export returned values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 #### Release 0.40.0
 
+Incompatible changes:
+
 - CHANGED: Renamed ExchangeAuthorizationError.HttpResponse field to ExchangeAuthorizationError.HTTPResponse
 - CHANGED: Renamed Response.HttpResponse field to Response.HTTPResponse
+- CHANGED: Changed all method signatures so that the returned value is exported (dnsimple/dnsimple-go#91)
 
 - REMOVED: Deleted deprecated ResetDomainToken method.
 

--- a/dnsimple/accounts.go
+++ b/dnsimple/accounts.go
@@ -17,8 +17,8 @@ type Account struct {
 	UpdatedAt      string `json:"updated_at,omitempty"`
 }
 
-// accountsResponse represents a response from an API method that returns a collection of Account struct.
-type accountsResponse struct {
+// AccountsResponse represents a response from an API method that returns a collection of Account struct.
+type AccountsResponse struct {
 	Response
 	Data []Account `json:"data"`
 }
@@ -26,9 +26,9 @@ type accountsResponse struct {
 // ListAccounts list the accounts for an user.
 //
 // See https://developer.dnsimple.com/v2/accounts/#list
-func (s *AccountsService) ListAccounts(options *ListOptions) (*accountsResponse, error) {
+func (s *AccountsService) ListAccounts(options *ListOptions) (*AccountsResponse, error) {
 	path := versioned("/accounts")
-	accountsResponse := &accountsResponse{}
+	accountsResponse := &AccountsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -84,32 +84,32 @@ func letsencryptCertificatePath(accountID, domainIdentifier string, certificateI
 	return
 }
 
-// certificateResponse represents a response from an API method that returns a Certificate struct.
-type certificateResponse struct {
+// CertificateResponse represents a response from an API method that returns a Certificate struct.
+type CertificateResponse struct {
 	Response
 	Data *Certificate `json:"data"`
 }
 
-// certificateBundleResponse represents a response from an API method that returns a CertificatBundle struct.
-type certificateBundleResponse struct {
+// CertificateBundleResponse represents a response from an API method that returns a CertificatBundle struct.
+type CertificateBundleResponse struct {
 	Response
 	Data *CertificateBundle `json:"data"`
 }
 
-// certificatesResponse represents a response from an API method that returns a collection of Certificate struct.
-type certificatesResponse struct {
+// CertificatesResponse represents a response from an API method that returns a collection of Certificate struct.
+type CertificatesResponse struct {
 	Response
 	Data []Certificate `json:"data"`
 }
 
-// certificatePurchaseResponse represents a response from an API method that returns a CertificatePurchase struct.
-type certificatePurchaseResponse struct {
+// CertificatePurchaseResponse represents a response from an API method that returns a CertificatePurchase struct.
+type CertificatePurchaseResponse struct {
 	Response
 	Data *CertificatePurchase `json:"data"`
 }
 
-// certificateRenewalResponse represents a response from an API method that returns a CertificateRenewal struct.
-type certificateRenewalResponse struct {
+// CertificateRenewalResponse represents a response from an API method that returns a CertificateRenewal struct.
+type CertificateRenewalResponse struct {
 	Response
 	Data *CertificateRenewal `json:"data"`
 }
@@ -117,9 +117,9 @@ type certificateRenewalResponse struct {
 // ListCertificates lists the certificates for a domain in the account.
 //
 // See https://developer.dnsimple.com/v2/certificates#listCertificates
-func (s *CertificatesService) ListCertificates(accountID, domainIdentifier string, options *ListOptions) (*certificatesResponse, error) {
+func (s *CertificatesService) ListCertificates(accountID, domainIdentifier string, options *ListOptions) (*CertificatesResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, 0))
-	certificatesResponse := &certificatesResponse{}
+	certificatesResponse := &CertificatesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -138,9 +138,9 @@ func (s *CertificatesService) ListCertificates(accountID, domainIdentifier strin
 // GetCertificate gets the details of a certificate.
 //
 // See https://developer.dnsimple.com/v2/certificates#getCertificate
-func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string, certificateID int64) (*certificateResponse, error) {
+func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string, certificateID int64) (*CertificateResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID))
-	certificateResponse := &certificateResponse{}
+	certificateResponse := &CertificateResponse{}
 
 	resp, err := s.client.get(path, certificateResponse)
 	if err != nil {
@@ -155,9 +155,9 @@ func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string,
 // along with the root certificate and intermediate chain.
 //
 // See https://developer.dnsimple.com/v2/certificates#downloadCertificate
-func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier string, certificateID int64) (*certificateBundleResponse, error) {
+func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier string, certificateID int64) (*CertificateBundleResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID) + "/download")
-	certificateBundleResponse := &certificateBundleResponse{}
+	certificateBundleResponse := &CertificateBundleResponse{}
 
 	resp, err := s.client.get(path, certificateBundleResponse)
 	if err != nil {
@@ -171,9 +171,9 @@ func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier st
 // GetCertificatePrivateKey gets the PEM-encoded certificate private key.
 //
 // See https://developer.dnsimple.com/v2/certificates#getCertificatePrivateKey
-func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifier string, certificateID int64) (*certificateBundleResponse, error) {
+func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifier string, certificateID int64) (*CertificateBundleResponse, error) {
 	path := versioned(certificatePath(accountID, domainIdentifier, certificateID) + "/private_key")
-	certificateBundleResponse := &certificateBundleResponse{}
+	certificateBundleResponse := &CertificateBundleResponse{}
 
 	resp, err := s.client.get(path, certificateBundleResponse)
 	if err != nil {
@@ -187,9 +187,9 @@ func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifi
 // PurchaseLetsencryptCertificate purchases a Let's Encrypt certificate.
 //
 // See https://developer.dnsimple.com/v2/certificates/#purchaseLetsencryptCertificate
-func (s *CertificatesService) PurchaseLetsencryptCertificate(accountID, domainIdentifier string, certificateAttributes LetsencryptCertificateAttributes) (*certificatePurchaseResponse, error) {
+func (s *CertificatesService) PurchaseLetsencryptCertificate(accountID, domainIdentifier string, certificateAttributes LetsencryptCertificateAttributes) (*CertificatePurchaseResponse, error) {
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, 0))
-	certificatePurchaseResponse := &certificatePurchaseResponse{}
+	certificatePurchaseResponse := &CertificatePurchaseResponse{}
 
 	resp, err := s.client.post(path, certificateAttributes, certificatePurchaseResponse)
 	if err != nil {
@@ -203,9 +203,9 @@ func (s *CertificatesService) PurchaseLetsencryptCertificate(accountID, domainId
 // IssueLetsencryptCertificate issues a pending Let's Encrypt certificate purchase order.
 //
 // See https://developer.dnsimple.com/v2/certificates/#issueLetsencryptCertificate
-func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdentifier string, certificateID int64) (*certificateResponse, error) {
+func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdentifier string, certificateID int64) (*CertificateResponse, error) {
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + "/issue")
-	certificateResponse := &certificateResponse{}
+	certificateResponse := &CertificateResponse{}
 
 	resp, err := s.client.post(path, nil, certificateResponse)
 	if err != nil {
@@ -219,9 +219,9 @@ func (s *CertificatesService) IssueLetsencryptCertificate(accountID, domainIdent
 // PurchaseLetsencryptCertificateRenewal purchases a Let's Encrypt certificate renewal.
 //
 // See https://developer.dnsimple.com/v2/certificates/#purchaseRenewalLetsencryptCertificate
-func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID int64, certificateAttributes LetsencryptCertificateAttributes) (*certificateRenewalResponse, error) {
+func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID int64, certificateAttributes LetsencryptCertificateAttributes) (*CertificateRenewalResponse, error) {
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + "/renewals")
-	certificateRenewalResponse := &certificateRenewalResponse{}
+	certificateRenewalResponse := &CertificateRenewalResponse{}
 
 	resp, err := s.client.post(path, certificateAttributes, certificateRenewalResponse)
 	if err != nil {
@@ -235,9 +235,9 @@ func (s *CertificatesService) PurchaseLetsencryptCertificateRenewal(accountID, d
 // IssueLetsencryptCertificateRenewal issues a pending Let's Encrypt certificate renewal order.
 //
 // See https://developer.dnsimple.com/v2/certificates/#issueRenewalLetsencryptCertificate
-func (s *CertificatesService) IssueLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID, certificateRenewalID int64) (*certificateResponse, error) {
+func (s *CertificatesService) IssueLetsencryptCertificateRenewal(accountID, domainIdentifier string, certificateID, certificateRenewalID int64) (*CertificateResponse, error) {
 	path := versioned(letsencryptCertificatePath(accountID, domainIdentifier, certificateID) + fmt.Sprintf("/renewals/%d/issue", certificateRenewalID))
-	certificateResponse := &certificateResponse{}
+	certificateResponse := &CertificateResponse{}
 
 	resp, err := s.client.post(path, nil, certificateResponse)
 	if err != nil {

--- a/dnsimple/contacts.go
+++ b/dnsimple/contacts.go
@@ -42,14 +42,14 @@ func contactPath(accountID string, contactID int64) (path string) {
 	return
 }
 
-// contactResponse represents a response from an API method that returns a Contact struct.
-type contactResponse struct {
+// ContactResponse represents a response from an API method that returns a Contact struct.
+type ContactResponse struct {
 	Response
 	Data *Contact `json:"data"`
 }
 
-// contactsResponse represents a response from an API method that returns a collection of Contact struct.
-type contactsResponse struct {
+// ContactsResponse represents a response from an API method that returns a collection of Contact struct.
+type ContactsResponse struct {
 	Response
 	Data []Contact `json:"data"`
 }
@@ -57,9 +57,9 @@ type contactsResponse struct {
 // ListContacts list the contacts for an account.
 //
 // See https://developer.dnsimple.com/v2/contacts/#list
-func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (*contactsResponse, error) {
+func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (*ContactsResponse, error) {
 	path := versioned(contactPath(accountID, 0))
-	contactsResponse := &contactsResponse{}
+	contactsResponse := &ContactsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -78,9 +78,9 @@ func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (
 // CreateContact creates a new contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#create
-func (s *ContactsService) CreateContact(accountID string, contactAttributes Contact) (*contactResponse, error) {
+func (s *ContactsService) CreateContact(accountID string, contactAttributes Contact) (*ContactResponse, error) {
 	path := versioned(contactPath(accountID, 0))
-	contactResponse := &contactResponse{}
+	contactResponse := &ContactResponse{}
 
 	resp, err := s.client.post(path, contactAttributes, contactResponse)
 	if err != nil {
@@ -94,9 +94,9 @@ func (s *ContactsService) CreateContact(accountID string, contactAttributes Cont
 // GetContact fetches a contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#get
-func (s *ContactsService) GetContact(accountID string, contactID int64) (*contactResponse, error) {
+func (s *ContactsService) GetContact(accountID string, contactID int64) (*ContactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
-	contactResponse := &contactResponse{}
+	contactResponse := &ContactResponse{}
 
 	resp, err := s.client.get(path, contactResponse)
 	if err != nil {
@@ -110,9 +110,9 @@ func (s *ContactsService) GetContact(accountID string, contactID int64) (*contac
 // UpdateContact updates a contact.
 //
 // See https://developer.dnsimple.com/v2/contacts/#update
-func (s *ContactsService) UpdateContact(accountID string, contactID int64, contactAttributes Contact) (*contactResponse, error) {
+func (s *ContactsService) UpdateContact(accountID string, contactID int64, contactAttributes Contact) (*ContactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
-	contactResponse := &contactResponse{}
+	contactResponse := &ContactResponse{}
 
 	resp, err := s.client.patch(path, contactAttributes, contactResponse)
 	if err != nil {
@@ -126,9 +126,9 @@ func (s *ContactsService) UpdateContact(accountID string, contactID int64, conta
 // DeleteContact PERMANENTLY deletes a contact from the account.
 //
 // See https://developer.dnsimple.com/v2/contacts/#delete
-func (s *ContactsService) DeleteContact(accountID string, contactID int64) (*contactResponse, error) {
+func (s *ContactsService) DeleteContact(accountID string, contactID int64) (*ContactResponse, error) {
 	path := versioned(contactPath(accountID, contactID))
-	contactResponse := &contactResponse{}
+	contactResponse := &ContactResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -36,14 +36,14 @@ func domainPath(accountID string, domainIdentifier string) (path string) {
 	return
 }
 
-// domainResponse represents a response from an API method that returns a Domain struct.
-type domainResponse struct {
+// DomainResponse represents a response from an API method that returns a Domain struct.
+type DomainResponse struct {
 	Response
 	Data *Domain `json:"data"`
 }
 
-// domainsResponse represents a response from an API method that returns a collection of Domain struct.
-type domainsResponse struct {
+// DomainsResponse represents a response from an API method that returns a collection of Domain struct.
+type DomainsResponse struct {
 	Response
 	Data []Domain `json:"data"`
 }
@@ -63,9 +63,9 @@ type DomainListOptions struct {
 // ListDomains lists the domains for an account.
 //
 // See https://developer.dnsimple.com/v2/domains/#list
-func (s *DomainsService) ListDomains(accountID string, options *DomainListOptions) (*domainsResponse, error) {
+func (s *DomainsService) ListDomains(accountID string, options *DomainListOptions) (*DomainsResponse, error) {
 	path := versioned(domainPath(accountID, ""))
-	domainsResponse := &domainsResponse{}
+	domainsResponse := &DomainsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -84,9 +84,9 @@ func (s *DomainsService) ListDomains(accountID string, options *DomainListOption
 // CreateDomain creates a new domain in the account.
 //
 // See https://developer.dnsimple.com/v2/domains/#create
-func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain) (*domainResponse, error) {
+func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain) (*DomainResponse, error) {
 	path := versioned(domainPath(accountID, ""))
-	domainResponse := &domainResponse{}
+	domainResponse := &DomainResponse{}
 
 	resp, err := s.client.post(path, domainAttributes, domainResponse)
 	if err != nil {
@@ -100,9 +100,9 @@ func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain)
 // GetDomain fetches a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/#get
-func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*domainResponse, error) {
+func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*DomainResponse, error) {
 	path := versioned(domainPath(accountID, domainIdentifier))
-	domainResponse := &domainResponse{}
+	domainResponse := &DomainResponse{}
 
 	resp, err := s.client.get(path, domainResponse)
 	if err != nil {
@@ -116,9 +116,9 @@ func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*
 // DeleteDomain PERMANENTLY deletes a domain from the account.
 //
 // See https://developer.dnsimple.com/v2/domains/#delete
-func (s *DomainsService) DeleteDomain(accountID string, domainIdentifier string) (*domainResponse, error) {
+func (s *DomainsService) DeleteDomain(accountID string, domainIdentifier string) (*DomainResponse, error) {
 	path := versioned(domainPath(accountID, domainIdentifier))
-	domainResponse := &domainResponse{}
+	domainResponse := &DomainResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -30,14 +30,14 @@ type CollaboratorAttributes struct {
 	Email string `json:"email,omitempty"`
 }
 
-// collaboratorResponse represents a response from an API method that returns a Collaborator struct.
-type collaboratorResponse struct {
+// CollaboratorResponse represents a response from an API method that returns a Collaborator struct.
+type CollaboratorResponse struct {
 	Response
 	Data *Collaborator `json:"data"`
 }
 
-// collaboratorsResponse represents a response from an API method that returns a collection of Collaborator struct.
-type collaboratorsResponse struct {
+// CollaboratorsResponse represents a response from an API method that returns a collection of Collaborator struct.
+type CollaboratorsResponse struct {
 	Response
 	Data []Collaborator `json:"data"`
 }
@@ -45,9 +45,9 @@ type collaboratorsResponse struct {
 // ListCollaborators list the collaborators for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#list
-func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*collaboratorsResponse, error) {
+func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*CollaboratorsResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
-	collaboratorsResponse := &collaboratorsResponse{}
+	collaboratorsResponse := &CollaboratorsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -66,9 +66,9 @@ func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, o
 // AddCollaborator adds a new collaborator to the domain in the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
-func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*collaboratorResponse, error) {
+func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*CollaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
-	collaboratorResponse := &collaboratorResponse{}
+	collaboratorResponse := &CollaboratorResponse{}
 
 	resp, err := s.client.post(path, attributes, collaboratorResponse)
 	if err != nil {
@@ -82,9 +82,9 @@ func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier stri
 // RemoveCollaborator PERMANENTLY deletes a domain from the account.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#remove
-func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID int64) (*collaboratorResponse, error) {
+func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID int64) (*CollaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
-	collaboratorResponse := &collaboratorResponse{}
+	collaboratorResponse := &CollaboratorResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/domains_delegation_signer_records.go
+++ b/dnsimple/domains_delegation_signer_records.go
@@ -22,14 +22,14 @@ func delegationSignerRecordPath(accountID string, domainIdentifier string, dsRec
 	return
 }
 
-// delegationSignerRecordResponse represents a response from an API method that returns a DelegationSignerRecord struct.
-type delegationSignerRecordResponse struct {
+// DelegationSignerRecordResponse represents a response from an API method that returns a DelegationSignerRecord struct.
+type DelegationSignerRecordResponse struct {
 	Response
 	Data *DelegationSignerRecord `json:"data"`
 }
 
-// delegationSignerRecordResponse represents a response from an API method that returns a DelegationSignerRecord struct.
-type delegationSignerRecordsResponse struct {
+// DelegationSignerRecordsResponse represents a response from an API method that returns a DelegationSignerRecord struct.
+type DelegationSignerRecordsResponse struct {
 	Response
 	Data []DelegationSignerRecord `json:"data"`
 }
@@ -37,9 +37,9 @@ type delegationSignerRecordsResponse struct {
 // ListDelegationSignerRecords lists the delegation signer records for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-list
-func (s *DomainsService) ListDelegationSignerRecords(accountID string, domainIdentifier string, options *ListOptions) (*delegationSignerRecordsResponse, error) {
+func (s *DomainsService) ListDelegationSignerRecords(accountID string, domainIdentifier string, options *ListOptions) (*DelegationSignerRecordsResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
-	dsRecordsResponse := &delegationSignerRecordsResponse{}
+	dsRecordsResponse := &DelegationSignerRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -58,9 +58,9 @@ func (s *DomainsService) ListDelegationSignerRecords(accountID string, domainIde
 // CreateDelegationSignerRecord creates a new delegation signer record.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-create
-func (s *DomainsService) CreateDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordAttributes DelegationSignerRecord) (*delegationSignerRecordResponse, error) {
+func (s *DomainsService) CreateDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordAttributes DelegationSignerRecord) (*DelegationSignerRecordResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
-	dsRecordResponse := &delegationSignerRecordResponse{}
+	dsRecordResponse := &DelegationSignerRecordResponse{}
 
 	resp, err := s.client.post(path, dsRecordAttributes, dsRecordResponse)
 	if err != nil {
@@ -74,9 +74,9 @@ func (s *DomainsService) CreateDelegationSignerRecord(accountID string, domainId
 // GetDelegationSignerRecord fetches a delegation signer record.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-get
-func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int64) (*delegationSignerRecordResponse, error) {
+func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int64) (*DelegationSignerRecordResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
-	dsRecordResponse := &delegationSignerRecordResponse{}
+	dsRecordResponse := &DelegationSignerRecordResponse{}
 
 	resp, err := s.client.get(path, dsRecordResponse)
 	if err != nil {
@@ -91,9 +91,9 @@ func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdent
 // from the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-delete
-func (s *DomainsService) DeleteDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int64) (*delegationSignerRecordResponse, error) {
+func (s *DomainsService) DeleteDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int64) (*DelegationSignerRecordResponse, error) {
 	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
-	dsRecordResponse := &delegationSignerRecordResponse{}
+	dsRecordResponse := &DelegationSignerRecordResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -14,8 +14,8 @@ func dnssecPath(accountID string, domainIdentifier string) (path string) {
 	return
 }
 
-// dnssecResponse represents a response from an API method that returns a Dnssec struct.
-type dnssecResponse struct {
+// DnssecResponse represents a response from an API method that returns a Dnssec struct.
+type DnssecResponse struct {
 	Response
 	Data *Dnssec `json:"data"`
 }
@@ -23,9 +23,9 @@ type dnssecResponse struct {
 // EnableDnssec enables DNSSEC on the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#enableDomainDnssec
-func (s *DomainsService) EnableDnssec(accountID string, domainIdentifier string) (*dnssecResponse, error) {
+func (s *DomainsService) EnableDnssec(accountID string, domainIdentifier string) (*DnssecResponse, error) {
 	path := versioned(dnssecPath(accountID, domainIdentifier))
-	dnssecResponse := &dnssecResponse{}
+	dnssecResponse := &DnssecResponse{}
 
 	resp, err := s.client.post(path, dnssecResponse, nil)
 	if err != nil {
@@ -39,9 +39,9 @@ func (s *DomainsService) EnableDnssec(accountID string, domainIdentifier string)
 // DisableDnssec disables DNSSEC on the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#disableDomainDnssec
-func (s *DomainsService) DisableDnssec(accountID string, domainIdentifier string) (*dnssecResponse, error) {
+func (s *DomainsService) DisableDnssec(accountID string, domainIdentifier string) (*DnssecResponse, error) {
 	path := versioned(dnssecPath(accountID, domainIdentifier))
-	dnssecResponse := &dnssecResponse{}
+	dnssecResponse := &DnssecResponse{}
 
 	resp, err := s.client.delete(path, dnssecResponse, nil)
 	if err != nil {
@@ -55,9 +55,9 @@ func (s *DomainsService) DisableDnssec(accountID string, domainIdentifier string
 // GetDnssec retrieves the current status of DNSSEC on the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#getDomainDnssec
-func (s *DomainsService) GetDnssec(accountID string, domainIdentifier string) (*dnssecResponse, error) {
+func (s *DomainsService) GetDnssec(accountID string, domainIdentifier string) (*DnssecResponse, error) {
 	path := versioned(dnssecPath(accountID, domainIdentifier))
-	dnssecResponse := &dnssecResponse{}
+	dnssecResponse := &DnssecResponse{}
 
 	resp, err := s.client.get(path, dnssecResponse)
 	if err != nil {

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -22,14 +22,14 @@ func emailForwardPath(accountID string, domainIdentifier string, forwardID int64
 	return
 }
 
-// emailForwardResponse represents a response from an API method that returns an EmailForward struct.
-type emailForwardResponse struct {
+// EmailForwardResponse represents a response from an API method that returns an EmailForward struct.
+type EmailForwardResponse struct {
 	Response
 	Data *EmailForward `json:"data"`
 }
 
-// emailForwardsResponse represents a response from an API method that returns a collection of EmailForward struct.
-type emailForwardsResponse struct {
+// EmailForwardsResponse represents a response from an API method that returns a collection of EmailForward struct.
+type EmailForwardsResponse struct {
 	Response
 	Data []EmailForward `json:"data"`
 }
@@ -37,9 +37,9 @@ type emailForwardsResponse struct {
 // ListEmailForwards lists the email forwards for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#list
-func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier string, options *ListOptions) (*emailForwardsResponse, error) {
+func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier string, options *ListOptions) (*EmailForwardsResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
-	forwardsResponse := &emailForwardsResponse{}
+	forwardsResponse := &EmailForwardsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -58,9 +58,9 @@ func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier st
 // CreateEmailForward creates a new email forward.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#create
-func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier string, forwardAttributes EmailForward) (*emailForwardResponse, error) {
+func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier string, forwardAttributes EmailForward) (*EmailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
-	forwardResponse := &emailForwardResponse{}
+	forwardResponse := &EmailForwardResponse{}
 
 	resp, err := s.client.post(path, forwardAttributes, forwardResponse)
 	if err != nil {
@@ -74,9 +74,9 @@ func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier s
 // GetEmailForward fetches an email forward.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#get
-func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier string, forwardID int64) (*emailForwardResponse, error) {
+func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier string, forwardID int64) (*EmailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
-	forwardResponse := &emailForwardResponse{}
+	forwardResponse := &EmailForwardResponse{}
 
 	resp, err := s.client.get(path, forwardResponse)
 	if err != nil {
@@ -90,9 +90,9 @@ func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier stri
 // DeleteEmailForward PERMANENTLY deletes an email forward from the domain.
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#delete
-func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier string, forwardID int64) (*emailForwardResponse, error) {
+func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier string, forwardID int64) (*EmailForwardResponse, error) {
 	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
-	forwardResponse := &emailForwardResponse{}
+	forwardResponse := &EmailForwardResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/domains_pushes.go
+++ b/dnsimple/domains_pushes.go
@@ -23,14 +23,14 @@ func domainPushPath(accountID string, pushID int64) (path string) {
 	return
 }
 
-// domainPushResponse represents a response from an API method that returns a DomainPush struct.
-type domainPushResponse struct {
+// DomainPushResponse represents a response from an API method that returns a DomainPush struct.
+type DomainPushResponse struct {
 	Response
 	Data *DomainPush `json:"data"`
 }
 
-// domainPushesResponse represents a response from an API method that returns a collection of DomainPush struct.
-type domainPushesResponse struct {
+// DomainPushesResponse represents a response from an API method that returns a collection of DomainPush struct.
+type DomainPushesResponse struct {
 	Response
 	Data []DomainPush `json:"data"`
 }
@@ -44,9 +44,9 @@ type DomainPushAttributes struct {
 // InitiatePush initiate a new domain push.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#initiate
-func (s *DomainsService) InitiatePush(accountID, domainID string, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
+func (s *DomainsService) InitiatePush(accountID, domainID string, pushAttributes DomainPushAttributes) (*DomainPushResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/pushes", domainPath(accountID, domainID)))
-	pushResponse := &domainPushResponse{}
+	pushResponse := &DomainPushResponse{}
 
 	resp, err := s.client.post(path, pushAttributes, pushResponse)
 	if err != nil {
@@ -60,9 +60,9 @@ func (s *DomainsService) InitiatePush(accountID, domainID string, pushAttributes
 // ListPushes lists the pushes for an account.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#list
-func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*domainPushesResponse, error) {
+func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*DomainPushesResponse, error) {
 	path := versioned(domainPushPath(accountID, 0))
-	pushesResponse := &domainPushesResponse{}
+	pushesResponse := &DomainPushesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -81,9 +81,9 @@ func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*do
 // AcceptPush accept a push for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#accept
-func (s *DomainsService) AcceptPush(accountID string, pushID int64, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
+func (s *DomainsService) AcceptPush(accountID string, pushID int64, pushAttributes DomainPushAttributes) (*DomainPushResponse, error) {
 	path := versioned(domainPushPath(accountID, pushID))
-	pushResponse := &domainPushResponse{}
+	pushResponse := &DomainPushResponse{}
 
 	resp, err := s.client.post(path, pushAttributes, nil)
 	if err != nil {
@@ -97,9 +97,9 @@ func (s *DomainsService) AcceptPush(accountID string, pushID int64, pushAttribut
 // RejectPush reject a push for a domain.
 //
 // See https://developer.dnsimple.com/v2/domains/pushes/#reject
-func (s *DomainsService) RejectPush(accountID string, pushID int64) (*domainPushResponse, error) {
+func (s *DomainsService) RejectPush(accountID string, pushID int64) (*DomainPushResponse, error) {
 	path := versioned(domainPushPath(accountID, pushID))
-	pushResponse := &domainPushResponse{}
+	pushResponse := &DomainPushResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/identity.go
+++ b/dnsimple/identity.go
@@ -15,8 +15,8 @@ type WhoamiData struct {
 	Account *Account `json:"account,omitempty"`
 }
 
-// whoamiResponse represents a response from an API method that returns a Whoami struct.
-type whoamiResponse struct {
+// WhoamiResponse represents a response from an API method that returns a Whoami struct.
+type WhoamiResponse struct {
 	Response
 	Data *WhoamiData `json:"data"`
 }
@@ -24,9 +24,9 @@ type whoamiResponse struct {
 // Whoami gets the current authenticate context.
 //
 // See https://developer.dnsimple.com/v2/whoami
-func (s *IdentityService) Whoami() (*whoamiResponse, error) {
+func (s *IdentityService) Whoami() (*WhoamiResponse, error) {
 	path := versioned("/whoami")
-	whoamiResponse := &whoamiResponse{}
+	whoamiResponse := &WhoamiResponse{}
 
 	resp, err := s.client.get(path, whoamiResponse)
 	if err != nil {

--- a/dnsimple/live_test.go
+++ b/dnsimple/live_test.go
@@ -104,8 +104,8 @@ func TestLive_Webhooks(t *testing.T) {
 
 	var err error
 	var webhook *Webhook
-	var webhookResponse *webhookResponse
-	var webhooksResponse *webhooksResponse
+	var webhookResponse *WebhookResponse
+	var webhooksResponse *WebhooksResponse
 
 	whoami, err := Whoami(dnsimpleClient)
 	if err != nil {

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -19,8 +19,8 @@ type DomainCheck struct {
 	Premium   bool   `json:"premium"`
 }
 
-// domainCheckResponse represents a response from a domain check request.
-type domainCheckResponse struct {
+// DomainCheckResponse represents a response from a domain check request.
+type DomainCheckResponse struct {
 	Response
 	Data *DomainCheck `json:"data"`
 }
@@ -28,9 +28,9 @@ type domainCheckResponse struct {
 // CheckDomain checks a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#check
-func (s *RegistrarService) CheckDomain(accountID string, domainName string) (*domainCheckResponse, error) {
+func (s *RegistrarService) CheckDomain(accountID string, domainName string) (*DomainCheckResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/check", accountID, domainName))
-	checkResponse := &domainCheckResponse{}
+	checkResponse := &DomainCheckResponse{}
 
 	resp, err := s.client.get(path, checkResponse)
 	if err != nil {
@@ -50,8 +50,8 @@ type DomainPremiumPrice struct {
 	Action string `json:"action"`
 }
 
-// domainPremiumPriceResponse represents a response from a domain premium price request.
-type domainPremiumPriceResponse struct {
+// DomainPremiumPriceResponse represents a response from a domain premium price request.
+type DomainPremiumPriceResponse struct {
 	Response
 	Data *DomainPremiumPrice `json:"data"`
 }
@@ -70,10 +70,10 @@ type DomainPremiumPriceOptions struct {
 // - renewal
 //
 // See https://developer.dnsimple.com/v2/registrar/#premium-price
-func (s *RegistrarService) GetDomainPremiumPrice(accountID string, domainName string, options *DomainPremiumPriceOptions) (*domainPremiumPriceResponse, error) {
+func (s *RegistrarService) GetDomainPremiumPrice(accountID string, domainName string, options *DomainPremiumPriceOptions) (*DomainPremiumPriceResponse, error) {
 	var err error
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/premium_price", accountID, domainName))
-	priceResponse := &domainPremiumPriceResponse{}
+	priceResponse := &DomainPremiumPriceResponse{}
 
 	if options != nil {
 		path, err = addURLQueryOptions(path, options)
@@ -104,8 +104,8 @@ type DomainRegistration struct {
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
-// domainRegistrationResponse represents a response from an API method that results in a domain registration.
-type domainRegistrationResponse struct {
+// DomainRegistrationResponse represents a response from an API method that results in a domain registration.
+type DomainRegistrationResponse struct {
 	Response
 	Data *DomainRegistration `json:"data"`
 }
@@ -128,9 +128,9 @@ type DomainRegisterRequest struct {
 // RegisterDomain registers a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#register
-func (s *RegistrarService) RegisterDomain(accountID string, domainName string, request *DomainRegisterRequest) (*domainRegistrationResponse, error) {
+func (s *RegistrarService) RegisterDomain(accountID string, domainName string, request *DomainRegisterRequest) (*DomainRegistrationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/registrations", accountID, domainName))
-	registrationResponse := &domainRegistrationResponse{}
+	registrationResponse := &DomainRegistrationResponse{}
 
 	// TODO: validate mandatory attributes RegistrantID
 
@@ -155,8 +155,8 @@ type DomainTransfer struct {
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
-// domainTransferResponse represents a response from an API method that results in a domain transfer.
-type domainTransferResponse struct {
+// DomainTransferResponse represents a response from an API method that results in a domain transfer.
+type DomainTransferResponse struct {
 	Response
 	Data *DomainTransfer `json:"data"`
 }
@@ -182,9 +182,9 @@ type DomainTransferRequest struct {
 // TransferDomain transfers a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#transferDomain
-func (s *RegistrarService) TransferDomain(accountID string, domainName string, request *DomainTransferRequest) (*domainTransferResponse, error) {
+func (s *RegistrarService) TransferDomain(accountID string, domainName string, request *DomainTransferRequest) (*DomainTransferResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfers", accountID, domainName))
-	transferResponse := &domainTransferResponse{}
+	transferResponse := &DomainTransferResponse{}
 
 	// TODO: validate mandatory attributes RegistrantID
 
@@ -197,8 +197,8 @@ func (s *RegistrarService) TransferDomain(accountID string, domainName string, r
 	return transferResponse, nil
 }
 
-// domainTransferOutResponse represents a response from an API method that results in a domain transfer out.
-type domainTransferOutResponse struct {
+// DomainTransferOutResponse represents a response from an API method that results in a domain transfer out.
+type DomainTransferOutResponse struct {
 	Response
 	Data *Domain `json:"data"`
 }
@@ -206,9 +206,9 @@ type domainTransferOutResponse struct {
 // TransferDomainOut prepares a domain for outbound transfer.
 //
 // See https://developer.dnsimple.com/v2/registrar/#authorizeDomainTransferOut
-func (s *RegistrarService) TransferDomainOut(accountID string, domainName string) (*domainTransferOutResponse, error) {
+func (s *RegistrarService) TransferDomainOut(accountID string, domainName string) (*DomainTransferOutResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/authorize_transfer_out", accountID, domainName))
-	transferResponse := &domainTransferOutResponse{}
+	transferResponse := &DomainTransferOutResponse{}
 
 	resp, err := s.client.post(path, nil, nil)
 	if err != nil {
@@ -229,8 +229,8 @@ type DomainRenewal struct {
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-// domainRenewalResponse represents a response from an API method that returns a domain renewal.
-type domainRenewalResponse struct {
+// DomainRenewalResponse represents a response from an API method that returns a domain renewal.
+type DomainRenewalResponse struct {
 	Response
 	Data *DomainRenewal `json:"data"`
 }
@@ -247,9 +247,9 @@ type DomainRenewRequest struct {
 // RenewDomain renews a domain name.
 //
 // See https://developer.dnsimple.com/v2/registrar/#register
-func (s *RegistrarService) RenewDomain(accountID string, domainName string, request *DomainRenewRequest) (*domainRenewalResponse, error) {
+func (s *RegistrarService) RenewDomain(accountID string, domainName string, request *DomainRenewRequest) (*DomainRenewalResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/renewals", accountID, domainName))
-	renewalResponse := &domainRenewalResponse{}
+	renewalResponse := &DomainRenewalResponse{}
 
 	resp, err := s.client.post(path, request, renewalResponse)
 	if err != nil {

--- a/dnsimple/registrar_auto_renewal.go
+++ b/dnsimple/registrar_auto_renewal.go
@@ -7,9 +7,9 @@ import (
 // EnableDomainAutoRenewal enables auto-renewal for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
-func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName string) (*domainResponse, error) {
+func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName string) (*DomainResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
-	domainResponse := &domainResponse{}
+	domainResponse := &DomainResponse{}
 
 	resp, err := s.client.put(path, nil, nil)
 	if err != nil {
@@ -23,9 +23,9 @@ func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName 
 // DisableDomainAutoRenewal disables auto-renewal for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
-func (s *RegistrarService) DisableDomainAutoRenewal(accountID string, domainName string) (*domainResponse, error) {
+func (s *RegistrarService) DisableDomainAutoRenewal(accountID string, domainName string) (*DomainResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
-	domainResponse := &domainResponse{}
+	domainResponse := &DomainResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/registrar_delegation.go
+++ b/dnsimple/registrar_delegation.go
@@ -7,14 +7,14 @@ import (
 // Delegation represents a list of name servers that correspond to a domain delegation.
 type Delegation []string
 
-// delegationResponse represents a response from an API method that returns a delegation struct.
-type delegationResponse struct {
+// DelegationResponse represents a response from an API method that returns a delegation struct.
+type DelegationResponse struct {
 	Response
 	Data *Delegation `json:"data"`
 }
 
-// vanityDelegationResponse represents a response for vanity name server enable and disable operations.
-type vanityDelegationResponse struct {
+// VanityDelegationResponse represents a response for vanity name server enable and disable operations.
+type VanityDelegationResponse struct {
 	Response
 	Data []VanityNameServer `json:"data"`
 }
@@ -22,9 +22,9 @@ type vanityDelegationResponse struct {
 // GetDomainDelegation gets the current delegated name servers for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#get
-func (s *RegistrarService) GetDomainDelegation(accountID string, domainName string) (*delegationResponse, error) {
+func (s *RegistrarService) GetDomainDelegation(accountID string, domainName string) (*DelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
-	delegationResponse := &delegationResponse{}
+	delegationResponse := &DelegationResponse{}
 
 	resp, err := s.client.get(path, delegationResponse)
 	if err != nil {
@@ -38,9 +38,9 @@ func (s *RegistrarService) GetDomainDelegation(accountID string, domainName stri
 // ChangeDomainDelegation updates the delegated name severs for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#get
-func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName string, newDelegation *Delegation) (*delegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName string, newDelegation *Delegation) (*DelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
-	delegationResponse := &delegationResponse{}
+	delegationResponse := &DelegationResponse{}
 
 	resp, err := s.client.put(path, newDelegation, delegationResponse)
 	if err != nil {
@@ -54,9 +54,9 @@ func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName s
 // ChangeDomainDelegationToVanity enables vanity name servers for the given domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#delegateToVanity
-func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, domainName string, newDelegation *Delegation) (*vanityDelegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, domainName string, newDelegation *Delegation) (*VanityDelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
-	delegationResponse := &vanityDelegationResponse{}
+	delegationResponse := &VanityDelegationResponse{}
 
 	resp, err := s.client.put(path, newDelegation, delegationResponse)
 	if err != nil {
@@ -70,9 +70,9 @@ func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, doma
 // ChangeDomainDelegationFromVanity disables vanity name servers for the given domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/delegation/#dedelegateFromVanity
-func (s *RegistrarService) ChangeDomainDelegationFromVanity(accountID string, domainName string) (*vanityDelegationResponse, error) {
+func (s *RegistrarService) ChangeDomainDelegationFromVanity(accountID string, domainName string) (*VanityDelegationResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
-	delegationResponse := &vanityDelegationResponse{}
+	delegationResponse := &VanityDelegationResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/registrar_whois_privacy.go
+++ b/dnsimple/registrar_whois_privacy.go
@@ -26,14 +26,14 @@ type WhoisPrivacyRenewal struct {
 	UpdatedAt      string `json:"updated_at,omitempty"`
 }
 
-// whoisPrivacyResponse represents a response from an API method that returns a WhoisPrivacy struct.
-type whoisPrivacyResponse struct {
+// WhoisPrivacyResponse represents a response from an API method that returns a WhoisPrivacy struct.
+type WhoisPrivacyResponse struct {
 	Response
 	Data *WhoisPrivacy `json:"data"`
 }
 
-// whoisPrivacyRenewalResponse represents a response from an API method that returns a WhoisPrivacyRenewal struct.
-type whoisPrivacyRenewalResponse struct {
+// WhoisPrivacyRenewalResponse represents a response from an API method that returns a WhoisPrivacyRenewal struct.
+type WhoisPrivacyRenewalResponse struct {
 	Response
 	Data *WhoisPrivacyRenewal `json:"data"`
 }
@@ -41,9 +41,9 @@ type whoisPrivacyRenewalResponse struct {
 // GetWhoisPrivacy gets the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#get
-func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
+func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
-	privacyResponse := &whoisPrivacyResponse{}
+	privacyResponse := &WhoisPrivacyResponse{}
 
 	resp, err := s.client.get(path, privacyResponse)
 	if err != nil {
@@ -57,9 +57,9 @@ func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) 
 // EnableWhoisPrivacy enables the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
-func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
+func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
-	privacyResponse := &whoisPrivacyResponse{}
+	privacyResponse := &WhoisPrivacyResponse{}
 
 	resp, err := s.client.put(path, nil, privacyResponse)
 	if err != nil {
@@ -73,9 +73,9 @@ func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName strin
 // DisableWhoisPrivacy disables the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
-func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
+func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
-	privacyResponse := &whoisPrivacyResponse{}
+	privacyResponse := &WhoisPrivacyResponse{}
 
 	resp, err := s.client.delete(path, nil, privacyResponse)
 	if err != nil {
@@ -89,9 +89,9 @@ func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName stri
 // RenewWhoisPrivacy renews the whois privacy for the domain.
 //
 // See https://developer.dnsimple.com/v2/registrar/whois-privacy/#renew
-func (s *RegistrarService) RenewWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyRenewalResponse, error) {
+func (s *RegistrarService) RenewWhoisPrivacy(accountID string, domainName string) (*WhoisPrivacyRenewalResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy/renewals", accountID, domainName))
-	privacyRenewalResponse := &whoisPrivacyRenewalResponse{}
+	privacyRenewalResponse := &WhoisPrivacyRenewalResponse{}
 
 	resp, err := s.client.post(path, nil, privacyRenewalResponse)
 	if err != nil {

--- a/dnsimple/services.go
+++ b/dnsimple/services.go
@@ -44,14 +44,14 @@ func servicePath(serviceIdentifier string) (path string) {
 	return
 }
 
-// serviceResponse represents a response from an API method that returns a Service struct.
-type serviceResponse struct {
+// ServiceResponse represents a response from an API method that returns a Service struct.
+type ServiceResponse struct {
 	Response
 	Data *Service `json:"data"`
 }
 
-// servicesResponse represents a response from an API method that returns a collection of Service struct.
-type servicesResponse struct {
+// ServicesResponse represents a response from an API method that returns a collection of Service struct.
+type ServicesResponse struct {
 	Response
 	Data []Service `json:"data"`
 }
@@ -59,9 +59,9 @@ type servicesResponse struct {
 // ListServices lists the one-click services available in DNSimple.
 //
 // See https://developer.dnsimple.com/v2/services/#list
-func (s *ServicesService) ListServices(options *ListOptions) (*servicesResponse, error) {
+func (s *ServicesService) ListServices(options *ListOptions) (*ServicesResponse, error) {
 	path := versioned(servicePath(""))
-	servicesResponse := &servicesResponse{}
+	servicesResponse := &ServicesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -80,9 +80,9 @@ func (s *ServicesService) ListServices(options *ListOptions) (*servicesResponse,
 // GetService fetches a one-click service.
 //
 // See https://developer.dnsimple.com/v2/services/#get
-func (s *ServicesService) GetService(serviceIdentifier string) (*serviceResponse, error) {
+func (s *ServicesService) GetService(serviceIdentifier string) (*ServiceResponse, error) {
 	path := versioned(servicePath(serviceIdentifier))
-	serviceResponse := &serviceResponse{}
+	serviceResponse := &ServiceResponse{}
 
 	resp, err := s.client.get(path, serviceResponse)
 	if err != nil {

--- a/dnsimple/services_domains.go
+++ b/dnsimple/services_domains.go
@@ -19,9 +19,9 @@ type DomainServiceSettings struct {
 // AppliedServices lists the applied one-click services for a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#applied
-func (s *ServicesService) AppliedServices(accountID string, domainIdentifier string, options *ListOptions) (*servicesResponse, error) {
+func (s *ServicesService) AppliedServices(accountID string, domainIdentifier string, options *ListOptions) (*ServicesResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainIdentifier, ""))
-	servicesResponse := &servicesResponse{}
+	servicesResponse := &ServicesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -40,9 +40,9 @@ func (s *ServicesService) AppliedServices(accountID string, domainIdentifier str
 // ApplyService applies a one-click services to a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#apply
-func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainIdentifier string, settings DomainServiceSettings) (*serviceResponse, error) {
+func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainIdentifier string, settings DomainServiceSettings) (*ServiceResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
-	serviceResponse := &serviceResponse{}
+	serviceResponse := &ServiceResponse{}
 
 	resp, err := s.client.post(path, settings, nil)
 	if err != nil {
@@ -56,9 +56,9 @@ func (s *ServicesService) ApplyService(accountID string, serviceIdentifier strin
 // UnapplyService unapplies a one-click services from a domain.
 //
 // See https://developer.dnsimple.com/v2/services/domains/#unapply
-func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainIdentifier string) (*serviceResponse, error) {
+func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainIdentifier string) (*ServiceResponse, error) {
 	path := versioned(domainServicesPath(accountID, domainIdentifier, serviceIdentifier))
-	serviceResponse := &serviceResponse{}
+	serviceResponse := &ServiceResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/templates.go
+++ b/dnsimple/templates.go
@@ -31,14 +31,14 @@ func templatePath(accountID string, templateIdentifier string) (path string) {
 	return
 }
 
-// templateResponse represents a response from an API method that returns a Template struct.
-type templateResponse struct {
+// TemplateResponse represents a response from an API method that returns a Template struct.
+type TemplateResponse struct {
 	Response
 	Data *Template `json:"data"`
 }
 
-// templatesResponse represents a response from an API method that returns a collection of Template struct.
-type templatesResponse struct {
+// TemplatesResponse represents a response from an API method that returns a collection of Template struct.
+type TemplatesResponse struct {
 	Response
 	Data []Template `json:"data"`
 }
@@ -46,9 +46,9 @@ type templatesResponse struct {
 // ListTemplates list the templates for an account.
 //
 // See https://developer.dnsimple.com/v2/templates/#list
-func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions) (*templatesResponse, error) {
+func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions) (*TemplatesResponse, error) {
 	path := versioned(templatePath(accountID, ""))
-	templatesResponse := &templatesResponse{}
+	templatesResponse := &TemplatesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -67,9 +67,9 @@ func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions)
 // CreateTemplate creates a new template.
 //
 // See https://developer.dnsimple.com/v2/templates/#create
-func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes Template) (*templateResponse, error) {
+func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes Template) (*TemplateResponse, error) {
 	path := versioned(templatePath(accountID, ""))
-	templateResponse := &templateResponse{}
+	templateResponse := &TemplateResponse{}
 
 	resp, err := s.client.post(path, templateAttributes, templateResponse)
 	if err != nil {
@@ -83,9 +83,9 @@ func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes T
 // GetTemplate fetches a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#get
-func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier string) (*templateResponse, error) {
+func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier string) (*TemplateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
-	templateResponse := &templateResponse{}
+	templateResponse := &TemplateResponse{}
 
 	resp, err := s.client.get(path, templateResponse)
 	if err != nil {
@@ -99,9 +99,9 @@ func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier stri
 // UpdateTemplate updates a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#update
-func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier string, templateAttributes Template) (*templateResponse, error) {
+func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier string, templateAttributes Template) (*TemplateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
-	templateResponse := &templateResponse{}
+	templateResponse := &TemplateResponse{}
 
 	resp, err := s.client.patch(path, templateAttributes, templateResponse)
 	if err != nil {
@@ -115,9 +115,9 @@ func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier s
 // DeleteTemplate deletes a template.
 //
 // See https://developer.dnsimple.com/v2/templates/#delete
-func (s *TemplatesService) DeleteTemplate(accountID string, templateIdentifier string) (*templateResponse, error) {
+func (s *TemplatesService) DeleteTemplate(accountID string, templateIdentifier string) (*TemplateResponse, error) {
 	path := versioned(templatePath(accountID, templateIdentifier))
-	templateResponse := &templateResponse{}
+	templateResponse := &TemplateResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/templates_domains.go
+++ b/dnsimple/templates_domains.go
@@ -7,9 +7,9 @@ import (
 // ApplyTemplate applies a template to the given domain.
 //
 // See https://developer.dnsimple.com/v2/templates/domains/#apply
-func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier string, domainIdentifier string) (*templateResponse, error) {
+func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier string, domainIdentifier string) (*TemplateResponse, error) {
 	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath(accountID, domainIdentifier), templateIdentifier))
-	templateResponse := &templateResponse{}
+	templateResponse := &TemplateResponse{}
 
 	resp, err := s.client.post(path, nil, nil)
 	if err != nil {

--- a/dnsimple/templates_records.go
+++ b/dnsimple/templates_records.go
@@ -25,14 +25,14 @@ func templateRecordPath(accountID string, templateIdentifier string, templateRec
 	return templatePath(accountID, templateIdentifier) + "/records"
 }
 
-// templateRecordResponse represents a response from an API method that returns a TemplateRecord struct.
-type templateRecordResponse struct {
+// TemplateRecordResponse represents a response from an API method that returns a TemplateRecord struct.
+type TemplateRecordResponse struct {
 	Response
 	Data *TemplateRecord `json:"data"`
 }
 
-// templateRecordsResponse represents a response from an API method that returns a collection of TemplateRecord struct.
-type templateRecordsResponse struct {
+// TemplateRecordsResponse represents a response from an API method that returns a collection of TemplateRecord struct.
+type TemplateRecordsResponse struct {
 	Response
 	Data []TemplateRecord `json:"data"`
 }
@@ -40,9 +40,9 @@ type templateRecordsResponse struct {
 // ListTemplateRecords list the templates for an account.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#list
-func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentifier string, options *ListOptions) (*templateRecordsResponse, error) {
+func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentifier string, options *ListOptions) (*TemplateRecordsResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
-	templateRecordsResponse := &templateRecordsResponse{}
+	templateRecordsResponse := &TemplateRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -61,9 +61,9 @@ func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentif
 // CreateTemplateRecord creates a new template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#create
-func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*templateRecordResponse, error) {
+func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*TemplateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, 0))
-	templateRecordResponse := &templateRecordResponse{}
+	templateRecordResponse := &TemplateRecordResponse{}
 
 	resp, err := s.client.post(path, templateRecordAttributes, templateRecordResponse)
 	if err != nil {
@@ -77,9 +77,9 @@ func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdenti
 // GetTemplateRecord fetches a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#get
-func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID int64) (*templateRecordResponse, error) {
+func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID int64) (*TemplateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
-	templateRecordResponse := &templateRecordResponse{}
+	templateRecordResponse := &TemplateRecordResponse{}
 
 	resp, err := s.client.get(path, templateRecordResponse)
 	if err != nil {
@@ -93,9 +93,9 @@ func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifie
 // DeleteTemplateRecord deletes a template record.
 //
 // See https://developer.dnsimple.com/v2/templates/records/#delete
-func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID int64) (*templateRecordResponse, error) {
+func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID int64) (*TemplateRecordResponse, error) {
 	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
-	templateRecordResponse := &templateRecordResponse{}
+	templateRecordResponse := &TemplateRecordResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -44,21 +44,21 @@ type TldExtendedAttributeOption struct {
 	Description string `json:"description"`
 }
 
-// tldResponse represents a response from an API method that returns a Tld struct.
-type tldResponse struct {
+// TldResponse represents a response from an API method that returns a Tld struct.
+type TldResponse struct {
 	Response
 	Data *Tld `json:"data"`
 }
 
-// tldsResponse represents a response from an API method that returns a collection of Tld struct.
-type tldsResponse struct {
+// TldsResponse represents a response from an API method that returns a collection of Tld struct.
+type TldsResponse struct {
 	Response
 	Data []Tld `json:"data"`
 }
 
-// tldExtendedAttributesResponse represents a response from an API method that returns
+// TldExtendedAttributesResponse represents a response from an API method that returns
 // a collection of Tld extended attributes.
-type tldExtendedAttributesResponse struct {
+type TldExtendedAttributesResponse struct {
 	Response
 	Data []TldExtendedAttribute `json:"data"`
 }
@@ -66,9 +66,9 @@ type tldExtendedAttributesResponse struct {
 // ListTlds lists the supported TLDs.
 //
 // See https://developer.dnsimple.com/v2/tlds/#list
-func (s *TldsService) ListTlds(options *ListOptions) (*tldsResponse, error) {
+func (s *TldsService) ListTlds(options *ListOptions) (*TldsResponse, error) {
 	path := versioned("/tlds")
-	tldsResponse := &tldsResponse{}
+	tldsResponse := &TldsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -87,9 +87,9 @@ func (s *TldsService) ListTlds(options *ListOptions) (*tldsResponse, error) {
 // GetTld fetches a TLD.
 //
 // See https://developer.dnsimple.com/v2/tlds/#get
-func (s *TldsService) GetTld(tld string) (*tldResponse, error) {
+func (s *TldsService) GetTld(tld string) (*TldResponse, error) {
 	path := versioned(fmt.Sprintf("/tlds/%s", tld))
-	tldResponse := &tldResponse{}
+	tldResponse := &TldResponse{}
 
 	resp, err := s.client.get(path, tldResponse)
 	if err != nil {
@@ -103,9 +103,9 @@ func (s *TldsService) GetTld(tld string) (*tldResponse, error) {
 // GetTldExtendedAttributes fetches the extended attributes of a TLD.
 //
 // See https://developer.dnsimple.com/v2/tlds/#get
-func (s *TldsService) GetTldExtendedAttributes(tld string) (*tldExtendedAttributesResponse, error) {
+func (s *TldsService) GetTldExtendedAttributes(tld string) (*TldExtendedAttributesResponse, error) {
 	path := versioned(fmt.Sprintf("/tlds/%s/extended_attributes", tld))
-	tldResponse := &tldExtendedAttributesResponse{}
+	tldResponse := &TldExtendedAttributesResponse{}
 
 	resp, err := s.client.get(path, tldResponse)
 	if err != nil {

--- a/dnsimple/vanity_name_server.go
+++ b/dnsimple/vanity_name_server.go
@@ -26,8 +26,8 @@ func vanityNameServerPath(accountID string, domainIdentifier string) string {
 	return fmt.Sprintf("/%v/vanity/%v", accountID, domainIdentifier)
 }
 
-// vanityNameServerResponse represents a response for vanity name server enable and disable operations.
-type vanityNameServerResponse struct {
+// VanityNameServerResponse represents a response for vanity name server enable and disable operations.
+type VanityNameServerResponse struct {
 	Response
 	Data []VanityNameServer `json:"data"`
 }
@@ -35,9 +35,9 @@ type vanityNameServerResponse struct {
 // EnableVanityNameServers Vanity Name Servers for the given domain
 //
 // See https://developer.dnsimple.com/v2/vanity/#enable
-func (s *VanityNameServersService) EnableVanityNameServers(accountID string, domainIdentifier string) (*vanityNameServerResponse, error) {
+func (s *VanityNameServersService) EnableVanityNameServers(accountID string, domainIdentifier string) (*VanityNameServerResponse, error) {
 	path := versioned(vanityNameServerPath(accountID, domainIdentifier))
-	vanityNameServerResponse := &vanityNameServerResponse{}
+	vanityNameServerResponse := &VanityNameServerResponse{}
 
 	resp, err := s.client.put(path, nil, vanityNameServerResponse)
 	if err != nil {
@@ -51,9 +51,9 @@ func (s *VanityNameServersService) EnableVanityNameServers(accountID string, dom
 // DisableVanityNameServers Vanity Name Servers for the given domain
 //
 // See https://developer.dnsimple.com/v2/vanity/#disable
-func (s *VanityNameServersService) DisableVanityNameServers(accountID string, domainIdentifier string) (*vanityNameServerResponse, error) {
+func (s *VanityNameServersService) DisableVanityNameServers(accountID string, domainIdentifier string) (*VanityNameServerResponse, error) {
 	path := versioned(vanityNameServerPath(accountID, domainIdentifier))
-	vanityNameServerResponse := &vanityNameServerResponse{}
+	vanityNameServerResponse := &VanityNameServerResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/webhook/webhook.go
+++ b/dnsimple/webhook/webhook.go
@@ -46,10 +46,12 @@ type EventDataContainer interface {
 	unmarshalEventData([]byte) error
 }
 
+// GetData returns the data container for the specific event type.
 func (e *Event) GetData() EventDataContainer {
 	return e.data
 }
 
+// GetPayload returns the data payload.
 func (e *Event) GetPayload() []byte {
 	return e.payload
 }

--- a/dnsimple/webhooks.go
+++ b/dnsimple/webhooks.go
@@ -26,14 +26,14 @@ func webhookPath(accountID string, webhookID int64) (path string) {
 	return
 }
 
-// webhookResponse represents a response from an API method that returns a Webhook struct.
-type webhookResponse struct {
+// WebhookResponse represents a response from an API method that returns a Webhook struct.
+type WebhookResponse struct {
 	Response
 	Data *Webhook `json:"data"`
 }
 
-// webhookResponse represents a response from an API method that returns a collection of Webhook struct.
-type webhooksResponse struct {
+// WebhooksResponse represents a response from an API method that returns a collection of Webhook struct.
+type WebhooksResponse struct {
 	Response
 	Data []Webhook `json:"data"`
 }
@@ -41,9 +41,9 @@ type webhooksResponse struct {
 // ListWebhooks lists the webhooks for an account.
 //
 // See https://developer.dnsimple.com/v2/webhooks#list
-func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*webhooksResponse, error) {
+func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*WebhooksResponse, error) {
 	path := versioned(webhookPath(accountID, 0))
-	webhooksResponse := &webhooksResponse{}
+	webhooksResponse := &WebhooksResponse{}
 
 	resp, err := s.client.get(path, webhooksResponse)
 	if err != nil {
@@ -57,9 +57,9 @@ func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*webho
 // CreateWebhook creates a new webhook.
 //
 // See https://developer.dnsimple.com/v2/webhooks#create
-func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webhook) (*webhookResponse, error) {
+func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webhook) (*WebhookResponse, error) {
 	path := versioned(webhookPath(accountID, 0))
-	webhookResponse := &webhookResponse{}
+	webhookResponse := &WebhookResponse{}
 
 	resp, err := s.client.post(path, webhookAttributes, webhookResponse)
 	if err != nil {
@@ -73,9 +73,9 @@ func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webh
 // GetWebhook fetches a webhook.
 //
 // See https://developer.dnsimple.com/v2/webhooks#get
-func (s *WebhooksService) GetWebhook(accountID string, webhookID int64) (*webhookResponse, error) {
+func (s *WebhooksService) GetWebhook(accountID string, webhookID int64) (*WebhookResponse, error) {
 	path := versioned(webhookPath(accountID, webhookID))
-	webhookResponse := &webhookResponse{}
+	webhookResponse := &WebhookResponse{}
 
 	resp, err := s.client.get(path, webhookResponse)
 	if err != nil {
@@ -89,9 +89,9 @@ func (s *WebhooksService) GetWebhook(accountID string, webhookID int64) (*webhoo
 // DeleteWebhook PERMANENTLY deletes a webhook from the account.
 //
 // See https://developer.dnsimple.com/v2/webhooks#delete
-func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int64) (*webhookResponse, error) {
+func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int64) (*WebhookResponse, error) {
 	path := versioned(webhookPath(accountID, webhookID))
-	webhookResponse := &webhookResponse{}
+	webhookResponse := &WebhookResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {

--- a/dnsimple/zone_distributions.go
+++ b/dnsimple/zone_distributions.go
@@ -7,8 +7,8 @@ type ZoneDistribution struct {
 	Distributed bool `json:"distributed"`
 }
 
-// zoneDistributionResponse represents a response from an API method that returns a ZoneDistribution struct.
-type zoneDistributionResponse struct {
+// ZoneDistributionResponse represents a response from an API method that returns a ZoneDistribution struct.
+type ZoneDistributionResponse struct {
 	Response
 	Data *ZoneDistribution `json:"data"`
 }
@@ -16,9 +16,9 @@ type zoneDistributionResponse struct {
 // CheckZoneDistribution checks if a zone is fully distributed across DNSimple nodes.
 //
 // See https://developer.dnsimple.com/v2/zones/#checkZoneDistribution
-func (s *ZonesService) CheckZoneDistribution(accountID string, zoneName string) (*zoneDistributionResponse, error) {
+func (s *ZonesService) CheckZoneDistribution(accountID string, zoneName string) (*ZoneDistributionResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v/distribution", accountID, zoneName))
-	zoneDistributionResponse := &zoneDistributionResponse{}
+	zoneDistributionResponse := &ZoneDistributionResponse{}
 
 	resp, err := s.client.get(path, zoneDistributionResponse)
 	if err != nil {
@@ -32,9 +32,9 @@ func (s *ZonesService) CheckZoneDistribution(accountID string, zoneName string) 
 // CheckZoneRecordDistribution checks if a zone is fully distributed across DNSimple nodes.
 //
 // See https://developer.dnsimple.com/v2/zones/#checkZoneRecordDistribution
-func (s *ZonesService) CheckZoneRecordDistribution(accountID string, zoneName string, recordID int64) (*zoneDistributionResponse, error) {
+func (s *ZonesService) CheckZoneRecordDistribution(accountID string, zoneName string, recordID int64) (*ZoneDistributionResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v/records/%v/distribution", accountID, zoneName, recordID))
-	zoneDistributionResponse := &zoneDistributionResponse{}
+	zoneDistributionResponse := &ZoneDistributionResponse{}
 
 	resp, err := s.client.get(path, zoneDistributionResponse)
 	if err != nil {

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -27,20 +27,20 @@ type ZoneFile struct {
 	Zone string `json:"zone,omitempty"`
 }
 
-// zoneResponse represents a response from an API method that returns a Zone struct.
-type zoneResponse struct {
+// ZoneResponse represents a response from an API method that returns a Zone struct.
+type ZoneResponse struct {
 	Response
 	Data *Zone `json:"data"`
 }
 
-// zonesResponse represents a response from an API method that returns a collection of Zone struct.
-type zonesResponse struct {
+// ZonesResponse represents a response from an API method that returns a collection of Zone struct.
+type ZonesResponse struct {
 	Response
 	Data []Zone `json:"data"`
 }
 
-// zoneFileResponse represents a response from an API method that returns a ZoneFile struct.
-type zoneFileResponse struct {
+// ZoneFileResponse represents a response from an API method that returns a ZoneFile struct.
+type ZoneFileResponse struct {
 	Response
 	Data *ZoneFile `json:"data"`
 }
@@ -57,9 +57,9 @@ type ZoneListOptions struct {
 // ListZones the zones for an account.
 //
 // See https://developer.dnsimple.com/v2/zones/#list
-func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*zonesResponse, error) {
+func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*ZonesResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones", accountID))
-	zonesResponse := &zonesResponse{}
+	zonesResponse := &ZonesResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -78,9 +78,9 @@ func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*z
 // GetZone fetches a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#get
-func (s *ZonesService) GetZone(accountID string, zoneName string) (*zoneResponse, error) {
+func (s *ZonesService) GetZone(accountID string, zoneName string) (*ZoneResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v", accountID, zoneName))
-	zoneResponse := &zoneResponse{}
+	zoneResponse := &ZoneResponse{}
 
 	resp, err := s.client.get(path, zoneResponse)
 	if err != nil {
@@ -94,9 +94,9 @@ func (s *ZonesService) GetZone(accountID string, zoneName string) (*zoneResponse
 // GetZoneFile fetches a zone file.
 //
 // See https://developer.dnsimple.com/v2/zones/#get-file
-func (s *ZonesService) GetZoneFile(accountID string, zoneName string) (*zoneFileResponse, error) {
+func (s *ZonesService) GetZoneFile(accountID string, zoneName string) (*ZoneFileResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/zones/%v/file", accountID, zoneName))
-	zoneFileResponse := &zoneFileResponse{}
+	zoneFileResponse := &ZoneFileResponse{}
 
 	resp, err := s.client.get(path, zoneFileResponse)
 	if err != nil {

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -28,14 +28,14 @@ func zoneRecordPath(accountID string, zoneName string, recordID int64) (path str
 	return
 }
 
-// zoneRecordResponse represents a response from an API method that returns a ZoneRecord struct.
-type zoneRecordResponse struct {
+// ZoneRecordResponse represents a response from an API method that returns a ZoneRecord struct.
+type ZoneRecordResponse struct {
 	Response
 	Data *ZoneRecord `json:"data"`
 }
 
-// zoneRecordsResponse represents a response from an API method that returns a collection of ZoneRecord struct.
-type zoneRecordsResponse struct {
+// ZoneRecordsResponse represents a response from an API method that returns a collection of ZoneRecord struct.
+type ZoneRecordsResponse struct {
 	Response
 	Data []ZoneRecord `json:"data"`
 }
@@ -59,9 +59,9 @@ type ZoneRecordListOptions struct {
 // ListRecords lists the zone records for a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#listZoneRecords
-func (s *ZonesService) ListRecords(accountID string, zoneName string, options *ZoneRecordListOptions) (*zoneRecordsResponse, error) {
+func (s *ZonesService) ListRecords(accountID string, zoneName string, options *ZoneRecordListOptions) (*ZoneRecordsResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, 0))
-	recordsResponse := &zoneRecordsResponse{}
+	recordsResponse := &ZoneRecordsResponse{}
 
 	path, err := addURLQueryOptions(path, options)
 	if err != nil {
@@ -80,9 +80,9 @@ func (s *ZonesService) ListRecords(accountID string, zoneName string, options *Z
 // CreateRecord creates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#createZoneRecord
-func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, 0))
-	recordResponse := &zoneRecordResponse{}
+	recordResponse := &ZoneRecordResponse{}
 
 	resp, err := s.client.post(path, recordAttributes, recordResponse)
 	if err != nil {
@@ -96,9 +96,9 @@ func (s *ZonesService) CreateRecord(accountID string, zoneName string, recordAtt
 // GetRecord fetches a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#getZoneRecord
-func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int64) (*zoneRecordResponse, error) {
+func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int64) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
-	recordResponse := &zoneRecordResponse{}
+	recordResponse := &ZoneRecordResponse{}
 
 	resp, err := s.client.get(path, recordResponse)
 	if err != nil {
@@ -112,9 +112,9 @@ func (s *ZonesService) GetRecord(accountID string, zoneName string, recordID int
 // UpdateRecord updates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#updateZoneRecord
-func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID int64, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID int64, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
-	recordResponse := &zoneRecordResponse{}
+	recordResponse := &ZoneRecordResponse{}
 	resp, err := s.client.patch(path, recordAttributes, recordResponse)
 
 	if err != nil {
@@ -128,9 +128,9 @@ func (s *ZonesService) UpdateRecord(accountID string, zoneName string, recordID 
 // DeleteRecord PERMANENTLY deletes a zone record from the zone.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#deleteZoneRecord
-func (s *ZonesService) DeleteRecord(accountID string, zoneName string, recordID int64) (*zoneRecordResponse, error) {
+func (s *ZonesService) DeleteRecord(accountID string, zoneName string, recordID int64) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
-	recordResponse := &zoneRecordResponse{}
+	recordResponse := &ZoneRecordResponse{}
 
 	resp, err := s.client.delete(path, nil, nil)
 	if err != nil {


### PR DESCRIPTION
In #54 I decided to change the method signatures to not export the response values. At a distance of few years, I believe this was probably not a good idea.

While it works in most cases, it makes more complex to implement testing. An example is when you need to create tests that will construct pagination.

https://github.com/kubernetes-sigs/external-dns/blob/master/provider/dnsimple_test.go#L105-L128

golint is also quite vocal about how _it may be annoying_ to not export the values.

I'm rolling back the changes in this PR. The good news is that since we forced the callers to never reference the value directly, this change should have very limited impact on anyone using the client.

Anyways, I'm working on several breaking changes as part of the next release, so it's a good time to include this PR as well.
