### PR TITLE
Handle case where ZoneRecord name can be not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+
+#### master
+
+- FIXED: A zone record can be updated without the risk of overridig the name by mistake (dnsimple/dnsimple-go#33, dnsimple/dnsimple-go#92) 
+
+Incompatible changes:
+
+- CHANGED: CreateZoneRecord and UpdateZoneRecord now requires to use ZoneRecordAttributes instead of ZoneRecord. This is required to avoid conflicts caused by blank record names (dnsimple/dnsimple-go#92)
+
+
 #### Release 0.50.0
 
 - NEW: Added Client.SetUserAgent() as a convenient helper to set a custom user agent.

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -370,3 +370,11 @@ func addURLQueryOptions(path string, options interface{}) (string, error) {
 
 	return u.String(), nil
 }
+
+// Int64P is a helper routine that allocates a new int64 value
+// to store v and returns a pointer to it.
+func Int64P(v int64) *int64 { return &v }
+
+// StringP is a helper routine that allocates a new string value
+// to store v and returns a pointer to it.
+func StringP(v string) *string { return &v }

--- a/dnsimple/live_test.go
+++ b/dnsimple/live_test.go
@@ -158,7 +158,8 @@ func TestLive_Zones(t *testing.T) {
 	}
 
 	zoneName := domainResponse.Data.Name
-	recordResponse, err := dnsimpleClient.Zones.CreateRecord(context.Background(), accountID, zoneName, ZoneRecord{Name: fmt.Sprintf("%v", time.Now().Unix()), Type: "TXT", Content: "Test"})
+	recordName := fmt.Sprintf("%v", time.Now().Unix())
+	recordResponse, err := dnsimpleClient.Zones.CreateRecord(context.Background(), accountID, zoneName, ZoneRecordAttributes{Name: &recordName, Type: "TXT", Content: "Test"})
 	if err != nil {
 		t.Fatalf("Live Zones/CreateRecord() returned error: %v", err)
 	}

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// ZoneRecord represents a DNS record in DNSimple.
+// ZoneRecord represents a zone record in DNSimple.
 type ZoneRecord struct {
 	ID           int64    `json:"id,omitempty"`
 	ZoneID       string   `json:"zone_id,omitempty"`
@@ -19,6 +19,21 @@ type ZoneRecord struct {
 	Regions      []string `json:"regions,omitempty"`
 	CreatedAt    string   `json:"created_at,omitempty"`
 	UpdatedAt    string   `json:"updated_at,omitempty"`
+}
+
+// ZoneRecordAttributes represents the attributes you can send to create/update a zone record.
+//
+// Compared to most other calls in this library, you should not use ZoneRecord as payload for record calls.
+// This is because it can lead to side effects due to the inability of go to distinguish between a non-present string
+// and an empty string. Name can be both, therefore a specific struct is required.
+type ZoneRecordAttributes struct {
+	ZoneID   string   `json:"zone_id,omitempty"`
+	Type     string   `json:"type,omitempty"`
+	Name     *string  `json:"name"`
+	Content  string   `json:"content,omitempty"`
+	TTL      int      `json:"ttl,omitempty"`
+	Priority int      `json:"priority,omitempty"`
+	Regions  []string `json:"regions,omitempty"`
 }
 
 func zoneRecordPath(accountID string, zoneName string, recordID int64) (path string) {
@@ -81,7 +96,7 @@ func (s *ZonesService) ListRecords(ctx context.Context, accountID string, zoneNa
 // CreateRecord creates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#createZoneRecord
-func (s *ZonesService) CreateRecord(ctx context.Context, accountID string, zoneName string, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
+func (s *ZonesService) CreateRecord(ctx context.Context, accountID string, zoneName string, recordAttributes ZoneRecordAttributes) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, 0))
 	recordResponse := &ZoneRecordResponse{}
 
@@ -113,7 +128,7 @@ func (s *ZonesService) GetRecord(ctx context.Context, accountID string, zoneName
 // UpdateRecord updates a zone record.
 //
 // See https://developer.dnsimple.com/v2/zones/records/#updateZoneRecord
-func (s *ZonesService) UpdateRecord(ctx context.Context, accountID string, zoneName string, recordID int64, recordAttributes ZoneRecord) (*ZoneRecordResponse, error) {
+func (s *ZonesService) UpdateRecord(ctx context.Context, accountID string, zoneName string, recordID int64, recordAttributes ZoneRecordAttributes) (*ZoneRecordResponse, error) {
 	path := versioned(zoneRecordPath(accountID, zoneName, recordID))
 	recordResponse := &ZoneRecordResponse{}
 	resp, err := s.client.patch(ctx, path, recordAttributes, recordResponse)

--- a/dnsimple/zones_records.go
+++ b/dnsimple/zones_records.go
@@ -29,7 +29,7 @@ type ZoneRecord struct {
 type ZoneRecordAttributes struct {
 	ZoneID   string   `json:"zone_id,omitempty"`
 	Type     string   `json:"type,omitempty"`
-	Name     *string  `json:"name"`
+	Name     *string  `json:"name,omitempty"`
 	Content  string   `json:"content,omitempty"`
 	TTL      int      `json:"ttl,omitempty"`
 	Priority int      `json:"priority,omitempty"`

--- a/dnsimple/zones_records_test.go
+++ b/dnsimple/zones_records_test.go
@@ -102,7 +102,7 @@ func TestZonesService_CreateRecord(t *testing.T) {
 	})
 
 	accountID := "1010"
-	recordValues := ZoneRecord{Name: "foo", Content: "mxa.example.com", Type: "MX"}
+	recordValues := ZoneRecordAttributes{Name: StringP("foo"), Content: "mxa.example.com", Type: "MX"}
 
 	recordResponse, err := client.Zones.CreateRecord(context.Background(), accountID, "example.com", recordValues)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestZonesService_CreateRecord_BlankName(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	recordValues := ZoneRecord{Name: "", Content: "127.0.0.1", Type: "A"}
+	recordValues := ZoneRecordAttributes{Name: StringP(""), Content: "127.0.0.1", Type: "A"}
 
 	recordResponse, err := client.Zones.CreateRecord(context.Background(), "1010", "example.com", recordValues)
 	if err != nil {
@@ -161,7 +161,7 @@ func TestZonesService_CreateRecord_Regions(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
-	var recordValues ZoneRecord
+	var recordValues ZoneRecordAttributes
 
 	mux.HandleFunc("/v2/1/zones/example.com/records", func(w http.ResponseWriter, r *http.Request) {
 		httpResponse := httpResponseFixture(t, "/api/createZoneRecord/created.http")
@@ -173,7 +173,8 @@ func TestZonesService_CreateRecord_Regions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	recordValues = ZoneRecord{Name: "foo", Regions: []string{}}
+	recordValues = ZoneRecordAttributes{Name: StringP("foo"), Regions: []string{}}
+
 	if _, err := client.Zones.CreateRecord(context.Background(), "1", "example.com", recordValues); err != nil {
 		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
 	}
@@ -188,7 +189,8 @@ func TestZonesService_CreateRecord_Regions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	recordValues = ZoneRecord{Name: "foo", Regions: []string{"global"}}
+	recordValues = ZoneRecordAttributes{Name: StringP("foo"), Regions: []string{"global"}}
+
 	if _, err := client.Zones.CreateRecord(context.Background(), "2", "example.com", recordValues); err != nil {
 		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
 	}
@@ -203,7 +205,8 @@ func TestZonesService_CreateRecord_Regions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	recordValues = ZoneRecord{Name: "foo", Regions: []string{"global"}}
+	recordValues = ZoneRecordAttributes{Name: StringP("foo"), Regions: []string{"global"}}
+
 	if _, err := client.Zones.CreateRecord(context.Background(), "2", "example.com", recordValues); err != nil {
 		t.Fatalf("Zones.CreateRecord() returned error: %v", err)
 	}
@@ -268,7 +271,7 @@ func TestZonesService_UpdateRecord(t *testing.T) {
 	})
 
 	accountID := "1010"
-	recordValues := ZoneRecord{Name: "foo", Content: "127.0.0.1"}
+	recordValues := ZoneRecordAttributes{Name: StringP("foo"), Content: "127.0.0.1"}
 
 	recordResponse, err := client.Zones.UpdateRecord(context.Background(), accountID, "example.com", 5, recordValues)
 	if err != nil {
@@ -288,7 +291,7 @@ func TestZonesService_UpdateRecord_Regions(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
-	var recordValues ZoneRecord
+	var recordValues ZoneRecordAttributes
 
 	mux.HandleFunc("/v2/1/zones/example.com/records/1", func(w http.ResponseWriter, r *http.Request) {
 		httpResponse := httpResponseFixture(t, "/api/updateZoneRecord/success.http")
@@ -300,7 +303,8 @@ func TestZonesService_UpdateRecord_Regions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	recordValues = ZoneRecord{Name: "foo", Regions: []string{}}
+	recordValues = ZoneRecordAttributes{Name: StringP("foo"), Regions: []string{}}
+
 	if _, err := client.Zones.UpdateRecord(context.Background(), "1", "example.com", 1, recordValues); err != nil {
 		t.Fatalf("Zones.UpdateRecord() returned error: %v", err)
 	}
@@ -315,7 +319,8 @@ func TestZonesService_UpdateRecord_Regions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	recordValues = ZoneRecord{Name: "foo", Regions: []string{"global"}}
+	recordValues = ZoneRecordAttributes{Name: StringP("foo"), Regions: []string{"global"}}
+
 	if _, err := client.Zones.UpdateRecord(context.Background(), "2", "example.com", 1, recordValues); err != nil {
 		t.Fatalf("Zones.UpdateRecord() returned error: %v", err)
 	}
@@ -330,7 +335,8 @@ func TestZonesService_UpdateRecord_Regions(t *testing.T) {
 		io.Copy(w, httpResponse.Body)
 	})
 
-	recordValues = ZoneRecord{Name: "foo", Regions: []string{"global"}}
+	recordValues = ZoneRecordAttributes{Name: StringP("foo"), Regions: []string{"global"}}
+
 	if _, err := client.Zones.UpdateRecord(context.Background(), "2", "example.com", 1, recordValues); err != nil {
 		t.Fatalf("Zones.UpdateRecord() returned error: %v", err)
 	}

--- a/dnsimple/zones_records_test.go
+++ b/dnsimple/zones_records_test.go
@@ -287,6 +287,28 @@ func TestZonesService_UpdateRecord(t *testing.T) {
 	}
 }
 
+func TestZonesService_UpdateRecord_NameNotProvided(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/zones/example.com/records/5", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/api/updateZoneRecord/success.http")
+
+		want := map[string]interface{}{"content": "127.0.0.1"}
+		testRequestJSON(t, r, want)
+
+		w.WriteHeader(httpResponse.StatusCode)
+		io.Copy(w, httpResponse.Body)
+	})
+
+	recordValues := ZoneRecordAttributes{Content: "127.0.0.1"}
+
+	_, err := client.Zones.UpdateRecord(context.Background(), "1010", "example.com", 5, recordValues)
+	if err != nil {
+		t.Fatalf("Zones.UpdateRecord() returned error: %v", err)
+	}
+}
+
 func TestZonesService_UpdateRecord_Regions(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()


### PR DESCRIPTION
A ZoneRecord name can be an empty value `""`. This is because our API mimic the UI and it requires the consumer to specify the zone record name without the zone, in other words not the qualified name.

As a result, when the qualified name also matches the zone name (for apex), the value of name is blank:

```
zone: example
record: www.example.com
-> name: "www"

zone: example
record: example.com
-> name: ""
```

In Go, there is no way to distinguish a non-present string (null) vs a blank string. That's because [the zero value](https://tour.golang.org/basics/12) of a string type is an empty string.

This is not a unique problem. Other libraries have a similar problem, such as the `sql` package and ORMs in general where a database string field can be null or empty.

There are 2 common approaches:

1. Define a custom type. This is what the `sql` package does with [`NullString`](https://golang.org/pkg/database/sql/#NullString).
1. Use a pointer to String. A pointer can be `nil`.

I tried both approaches, and I discarded the custom type as it was too much work for no real gain (the `sql` package also define custom interfaces for that values). So I went with a pointer. But changing `ZoneRecord` would have been quite painful for consumers as each time you referenced `Name` you would have had to remember it's a pointer.

While working on the pointer solution I realized that the pointer is really only needed for API requests. There is no case where name can be null for a real record, so consuming the API would always require a record name to be present, either blank or filled. So I decided to not change the signature of ZoneRecord but instead supply a different type of record attributes. This is actually another quite common pattern for particularly complex requests, and we also use in the [Registrar](https://github.com/dnsimple/dnsimple-go/blob/master/dnsimple/registrar.go#L134) where we supply special input structs to handle the payload of the registrar calls. This time I went with `-Attributes` and not `-Input` as there is a direct relationship between this struct at the zone record attributes, as well the zone record struct.

Fixes https://github.com/dnsimple/dnsimple-go/issues/33