### PR TITLE
Implement client methods for Transfer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 
-#### master
+#### Release 0.60.0
 
 - FIXED: A zone record can be updated without the risk of overriding the name by mistake (dnsimple/dnsimple-go#33, dnsimple/dnsimple-go#92) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # CHANGELOG
 
+#### master
+
+- NEW: Added Registrar.GetDomainTransfer() to retrieves a domain transfer. (dnsimple/dnsimple-go#94)
+- NEW: Added Registrar.CancelDomainTransfer() to cancel an in progress domain transfer. (dnsimple/dnsimple-go#94)
 
 #### Release 0.60.0
 
-- FIXED: A zone record can be updated without the risk of overriding the name by mistake (dnsimple/dnsimple-go#33, dnsimple/dnsimple-go#92) 
+- FIXED: A zone record can be updated without the risk of overriding the name by mistake (dnsimple/dnsimple-go#33, dnsimple/dnsimple-go#92)
 
-- FIXED: Fixed a conflict where a Go zero-value would prevent sorting to work correctly (dnsimple/dnsimple-go#88, dnsimple/dnsimple-go#93) 
+- FIXED: Fixed a conflict where a Go zero-value would prevent sorting to work correctly (dnsimple/dnsimple-go#88, dnsimple/dnsimple-go#93)
 
 Incompatible changes:
 

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -25,7 +25,7 @@ const (
 	// This is a pro-forma convention given that Go dependencies
 	// tends to be fetched directly from the repo.
 	// It is also used in the user-agent identify the client.
-	Version = "0.45.0"
+	Version = "0.60.0"
 
 	// defaultBaseURL to the DNSimple production API.
 	defaultBaseURL = "https://api.dnsimple.com"

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -202,6 +202,38 @@ func (s *RegistrarService) TransferDomain(ctx context.Context, accountID string,
 	return transferResponse, nil
 }
 
+// GetDomainTransfer fetches a domain transfer.
+//
+// See https://developer.dnsimple.com/v2/registrar/#getDomainTransfer
+func (s *RegistrarService) GetDomainTransfer(ctx context.Context, accountID string, domainName string, domainTransferID int64) (*DomainTransferResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfers/%v", accountID, domainName, domainTransferID))
+	transferResponse := &DomainTransferResponse{}
+
+	resp, err := s.client.get(ctx, path, transferResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	transferResponse.HTTPResponse = resp
+	return transferResponse, nil
+}
+
+// CancelDomainTransfer cancels an in progress domain transfer.
+//
+// See https://developer.dnsimple.com/v2/registrar/#cancelDomainTransfer
+func (s *RegistrarService) CancelDomainTransfer(ctx context.Context, accountID string, domainName string, domainTransferID int64) (*DomainTransferResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfers/%v", accountID, domainName, domainTransferID))
+	transferResponse := &DomainTransferResponse{}
+
+	resp, err := s.client.delete(ctx, path, nil, transferResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	transferResponse.HTTPResponse = resp
+	return transferResponse, nil
+}
+
 // DomainTransferOutResponse represents a response from an API method that results in a domain transfer out.
 type DomainTransferOutResponse struct {
 	Response

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -148,14 +148,15 @@ func (s *RegistrarService) RegisterDomain(ctx context.Context, accountID string,
 
 // DomainTransfer represents the result of a domain renewal call.
 type DomainTransfer struct {
-	ID           int    `json:"id"`
-	DomainID     int    `json:"domain_id"`
-	RegistrantID int    `json:"registrant_id"`
-	State        string `json:"state"`
-	AutoRenew    bool   `json:"auto_renew"`
-	WhoisPrivacy bool   `json:"whois_privacy"`
-	CreatedAt    string `json:"created_at,omitempty"`
-	UpdatedAt    string `json:"updated_at,omitempty"`
+	ID                int    `json:"id"`
+	DomainID          int    `json:"domain_id"`
+	RegistrantID      int    `json:"registrant_id"`
+	State             string `json:"state"`
+	AutoRenew         bool   `json:"auto_renew"`
+	WhoisPrivacy      bool   `json:"whois_privacy"`
+	StatusDescription string `json:"status_description"`
+	CreatedAt         string `json:"created_at,omitempty"`
+	UpdatedAt         string `json:"updated_at,omitempty"`
 }
 
 // DomainTransferResponse represents a response from an API method that results in a domain transfer.

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -237,14 +237,15 @@ func TestRegistrarService_GetDomainTransfer(t *testing.T) {
 	}
 	domainTransfer := domainTransferResponse.Data
 	wantSingle := &DomainTransfer{
-		ID:           1,
-		DomainID:     2,
-		RegistrantID: 3,
-		State:        "cancelled",
-		AutoRenew:    false,
-		WhoisPrivacy: false,
-		CreatedAt:    "2020-04-27T18:08:44Z",
-		UpdatedAt:    "2020-04-27T18:20:01Z"}
+		ID:                1,
+		DomainID:          2,
+		RegistrantID:      3,
+		State:             "cancelled",
+		AutoRenew:         false,
+		WhoisPrivacy:      false,
+    StatusDescription: "Canceled by customer",
+		CreatedAt:         "2020-04-27T18:08:44Z",
+		UpdatedAt:         "2020-04-27T18:20:01Z"}
 
 	if !reflect.DeepEqual(domainTransfer, wantSingle) {
 		t.Fatalf("Registrar.GetDomainTransfer() returned %+v, want %+v", domainTransfer, wantSingle)
@@ -271,14 +272,15 @@ func TestRegistrarService_CancelDomainTransfer(t *testing.T) {
 	}
 	domainTransfer := domainTransferResponse.Data
 	wantSingle := &DomainTransfer{
-		ID:           5,
-		DomainID:     6,
-		RegistrantID: 1,
-		State:        "transferring",
-		AutoRenew:    true,
-		WhoisPrivacy: false,
-		CreatedAt:    "2020-04-24T19:19:03Z",
-		UpdatedAt:    "2020-04-24T19:19:15Z"}
+		ID:                5,
+		DomainID:          6,
+		RegistrantID:      1,
+		State:             "transferring",
+		AutoRenew:         true,
+		WhoisPrivacy:      false,
+    StatusDescription: "",
+		CreatedAt:         "2020-04-24T19:19:03Z",
+		UpdatedAt:         "2020-04-24T19:19:15Z"}
 
 	if !reflect.DeepEqual(domainTransfer, wantSingle) {
 		t.Fatalf("Registrar.CancelDomainTransfer() returned %+v, want %+v", domainTransfer, wantSingle)

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -243,7 +243,7 @@ func TestRegistrarService_GetDomainTransfer(t *testing.T) {
 		State:             "cancelled",
 		AutoRenew:         false,
 		WhoisPrivacy:      false,
-    StatusDescription: "Canceled by customer",
+		StatusDescription: "Canceled by customer",
 		CreatedAt:         "2020-04-27T18:08:44Z",
 		UpdatedAt:         "2020-04-27T18:20:01Z"}
 
@@ -278,7 +278,7 @@ func TestRegistrarService_CancelDomainTransfer(t *testing.T) {
 		State:             "transferring",
 		AutoRenew:         true,
 		WhoisPrivacy:      false,
-    StatusDescription: "",
+		StatusDescription: "",
 		CreatedAt:         "2020-04-24T19:19:03Z",
 		UpdatedAt:         "2020-04-24T19:19:15Z"}
 

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -217,6 +217,74 @@ func TestRegistrarService_TransferDomainOut(t *testing.T) {
 	}
 }
 
+func TestRegistrarService_GetDomainTransfer(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/registrar/domains/example.com/transfers/1", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/api/getDomainTransfer/success.http")
+
+		testMethod(t, r, "GET")
+		testHeaders(t, r)
+
+		w.WriteHeader(httpResponse.StatusCode)
+		io.Copy(w, httpResponse.Body)
+	})
+
+	domainTransferResponse, err := client.Registrar.GetDomainTransfer(context.Background(), "1010", "example.com", 1)
+	if err != nil {
+		t.Fatalf("Registrar.GetDomainTransfer() returned error: %v", err)
+	}
+	domainTransfer := domainTransferResponse.Data
+	wantSingle := &DomainTransfer{
+		ID:           1,
+		DomainID:     2,
+		RegistrantID: 3,
+		State:        "cancelled",
+		AutoRenew:    false,
+		WhoisPrivacy: false,
+		CreatedAt:    "2020-04-27T18:08:44Z",
+		UpdatedAt:    "2020-04-27T18:20:01Z"}
+
+	if !reflect.DeepEqual(domainTransfer, wantSingle) {
+		t.Fatalf("Registrar.GetDomainTransfer() returned %+v, want %+v", domainTransfer, wantSingle)
+	}
+}
+
+func TestRegistrarService_CancelDomainTransfer(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/registrar/domains/example.com/transfers/1", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/api/cancelDomainTransfer/success.http")
+
+		testMethod(t, r, "DELETE")
+		testHeaders(t, r)
+
+		w.WriteHeader(httpResponse.StatusCode)
+		io.Copy(w, httpResponse.Body)
+	})
+
+	domainTransferResponse, err := client.Registrar.CancelDomainTransfer(context.Background(), "1010", "example.com", 1)
+	if err != nil {
+		t.Fatalf("Registrar.CancelDomainTransfer() returned error: %v", err)
+	}
+	domainTransfer := domainTransferResponse.Data
+	wantSingle := &DomainTransfer{
+		ID:           5,
+		DomainID:     6,
+		RegistrantID: 1,
+		State:        "transferring",
+		AutoRenew:    true,
+		WhoisPrivacy: false,
+		CreatedAt:    "2020-04-24T19:19:03Z",
+		UpdatedAt:    "2020-04-24T19:19:15Z"}
+
+	if !reflect.DeepEqual(domainTransfer, wantSingle) {
+		t.Fatalf("Registrar.CancelDomainTransfer() returned %+v, want %+v", domainTransfer, wantSingle)
+	}
+}
+
 func TestRegistrarService_RenewDomain(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()

--- a/fixtures.http/api/cancelDomainTransfer/success.http
+++ b/fixtures.http/api/cancelDomainTransfer/success.http
@@ -22,7 +22,6 @@ Strict-Transport-Security: max-age=31536000
     "state": "transferring",
     "auto_renew": true,
     "whois_privacy": false,
-    "premium_price": null,
     "status_description": null,
     "created_at": "2020-04-24T19:19:03Z",
     "updated_at": "2020-04-24T19:19:15Z"

--- a/fixtures.http/api/cancelDomainTransfer/success.http
+++ b/fixtures.http/api/cancelDomainTransfer/success.http
@@ -23,6 +23,7 @@ Strict-Transport-Security: max-age=31536000
     "auto_renew": true,
     "whois_privacy": false,
     "premium_price": null,
+    "status_description": null,
     "created_at": "2020-04-24T19:19:03Z",
     "updated_at": "2020-04-24T19:19:15Z"
   }

--- a/fixtures.http/api/cancelDomainTransfer/success.http
+++ b/fixtures.http/api/cancelDomainTransfer/success.http
@@ -22,6 +22,7 @@ Strict-Transport-Security: max-age=31536000
     "state": "transferring",
     "auto_renew": true,
     "whois_privacy": false,
+    "premium_price": null,
     "status_description": null,
     "created_at": "2020-04-24T19:19:03Z",
     "updated_at": "2020-04-24T19:19:15Z"

--- a/fixtures.http/api/cancelDomainTransfer/success.http
+++ b/fixtures.http/api/cancelDomainTransfer/success.http
@@ -1,0 +1,29 @@
+HTTP/1.1 202 Accepted
+Server: nginx
+Date: Wed, 29 Apr 2020 19:49:41 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 202 Accepted
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1588193270
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: no-store, must-revalidate, private, max-age=0
+X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
+X-Runtime: 1.752154
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 5,
+    "domain_id": 6,
+    "registrant_id": 1,
+    "state": "transferring",
+    "auto_renew": true,
+    "whois_privacy": false,
+    "premium_price": null,
+    "created_at": "2020-04-24T19:19:03Z",
+    "updated_at": "2020-04-24T19:19:15Z"
+  }
+}

--- a/fixtures.http/api/getDomainTransfer/success.http
+++ b/fixtures.http/api/getDomainTransfer/success.http
@@ -23,6 +23,7 @@ Strict-Transport-Security: max-age=31536000
     "auto_renew": false,
     "whois_privacy": false,
     "premium_price": null,
+    "status_description": "Canceled by customer",
     "created_at": "2020-04-27T18:08:44Z",
     "updated_at": "2020-04-27T18:20:01Z"
   }

--- a/fixtures.http/api/getDomainTransfer/success.http
+++ b/fixtures.http/api/getDomainTransfer/success.http
@@ -22,7 +22,6 @@ Strict-Transport-Security: max-age=31536000
     "state": "cancelled",
     "auto_renew": false,
     "whois_privacy": false,
-    "premium_price": null,
     "status_description": "Canceled by customer",
     "created_at": "2020-04-27T18:08:44Z",
     "updated_at": "2020-04-27T18:20:01Z"

--- a/fixtures.http/api/getDomainTransfer/success.http
+++ b/fixtures.http/api/getDomainTransfer/success.http
@@ -1,0 +1,29 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 27 Apr 2020 19:40:00 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1588019949
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
+X-Runtime: 0.092854
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 1,
+    "domain_id": 2,
+    "registrant_id": 3,
+    "state": "cancelled",
+    "auto_renew": false,
+    "whois_privacy": false,
+    "premium_price": null,
+    "created_at": "2020-04-27T18:08:44Z",
+    "updated_at": "2020-04-27T18:20:01Z"
+  }
+}

--- a/fixtures.http/api/getDomainTransfer/success.http
+++ b/fixtures.http/api/getDomainTransfer/success.http
@@ -22,6 +22,7 @@ Strict-Transport-Security: max-age=31536000
     "state": "cancelled",
     "auto_renew": false,
     "whois_privacy": false,
+    "premium_price": null,
     "status_description": "Canceled by customer",
     "created_at": "2020-04-27T18:08:44Z",
     "updated_at": "2020-04-27T18:20:01Z"


### PR DESCRIPTION
This commit introduces two client methods for the new features in
TransferAPI:
- getDomainTransfer - Retrieves the information for a specific domain
transfer
- cancelDomainTransfer - Cancels an in progress domain transfer