### PR TITLE
Fix type of DomainRegistration.(ID|DomainID|RegistrantID) to int64

### DIFF
--- a/dnsimple/oauth.go
+++ b/dnsimple/oauth.go
@@ -30,7 +30,7 @@ type OauthService struct {
 type AccessToken struct {
 	Token     string `json:"access_token"`
 	Type      string `json:"token_type"`
-	AccountID int    `json:"account_id"`
+	AccountID int64  `json:"account_id"`
 }
 
 // ExchangeAuthorizationRequest represents a request to exchange

--- a/dnsimple/oauth_test.go
+++ b/dnsimple/oauth_test.go
@@ -33,7 +33,7 @@ func TestOauthService_ExchangeAuthorizationForToken(t *testing.T) {
 		t.Fatalf("Oauth.ExchangeAuthorizationForToken() returned error: %v", err)
 	}
 
-	want := &AccessToken{Token: "zKQ7OLqF5N1gylcJweA9WodA000BUNJD", Type: "Bearer", AccountID: 1}
+	want := &AccessToken{Token: "zKQ7OLqF5N1gylcJweA9WodA000BUNJD", Type: "Bearer", AccountID: int64(1)}
 	if !reflect.DeepEqual(token, want) {
 		t.Errorf("Oauth.ExchangeAuthorizationForToken() returned %+v, want %+v", token, want)
 	}

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -148,9 +148,9 @@ func (s *RegistrarService) RegisterDomain(ctx context.Context, accountID string,
 
 // DomainTransfer represents the result of a domain renewal call.
 type DomainTransfer struct {
-	ID                int    `json:"id"`
-	DomainID          int    `json:"domain_id"`
-	RegistrantID      int    `json:"registrant_id"`
+	ID                int64  `json:"id"`
+	DomainID          int64  `json:"domain_id"`
+	RegistrantID      int64  `json:"registrant_id"`
 	State             string `json:"state"`
 	AutoRenew         bool   `json:"auto_renew"`
 	WhoisPrivacy      bool   `json:"whois_privacy"`

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -94,9 +94,9 @@ func (s *RegistrarService) GetDomainPremiumPrice(ctx context.Context, accountID 
 
 // DomainRegistration represents the result of a domain renewal call.
 type DomainRegistration struct {
-	ID           int    `json:"id"`
-	DomainID     int    `json:"domain_id"`
-	RegistrantID int    `json:"registrant_id"`
+	ID           int64  `json:"id"`
+	DomainID     int64  `json:"domain_id"`
+	RegistrantID int64  `json:"registrant_id"`
 	Period       int    `json:"period"`
 	State        string `json:"state"`
 	AutoRenew    bool   `json:"auto_renew"`

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -259,8 +259,8 @@ func (s *RegistrarService) TransferDomainOut(ctx context.Context, accountID stri
 
 // DomainRenewal represents the result of a domain renewal call.
 type DomainRenewal struct {
-	ID        int    `json:"id"`
-	DomainID  int    `json:"domain_id"`
+	ID        int64  `json:"id"`
+	DomainID  int64  `json:"domain_id"`
 	Period    int    `json:"period"`
 	State     string `json:"state"`
 	CreatedAt string `json:"created_at,omitempty"`

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -310,10 +310,10 @@ func TestRegistrarService_RenewDomain(t *testing.T) {
 	}
 
 	renewal := renewalResponse.Data
-	if want, got := 1, renewal.ID; want != got {
+	if want, got := int64(1), renewal.ID; want != got {
 		t.Fatalf("Registrar.RenewDomain() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 999, renewal.DomainID; want != got {
+	if want, got := int64(999), renewal.DomainID; want != got {
 		t.Fatalf("Registrar.RenewDomain() returned DomainID expected to be `%v`, got `%v`", want, got)
 	}
 }

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -165,10 +165,10 @@ func TestRegistrarService_TransferDomain(t *testing.T) {
 	}
 
 	transfer := transferResponse.Data
-	if want, got := 1, transfer.ID; want != got {
+	if want, got := int64(1), transfer.ID; want != got {
 		t.Fatalf("Registrar.TransferDomain() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 999, transfer.DomainID; want != got {
+	if want, got := int64(999), transfer.DomainID; want != got {
 		t.Fatalf("Registrar.TransferDomain() returned DomainID expected to be `%v`, got `%v`", want, got)
 	}
 }
@@ -237,9 +237,9 @@ func TestRegistrarService_GetDomainTransfer(t *testing.T) {
 	}
 	domainTransfer := domainTransferResponse.Data
 	wantSingle := &DomainTransfer{
-		ID:                361,
-		DomainID:          182245,
-		RegistrantID:      2715,
+		ID:                int64(361),
+		DomainID:          int64(182245),
+		RegistrantID:      int64(2715),
 		State:             "cancelled",
 		AutoRenew:         false,
 		WhoisPrivacy:      false,
@@ -272,9 +272,9 @@ func TestRegistrarService_CancelDomainTransfer(t *testing.T) {
 	}
 	domainTransfer := domainTransferResponse.Data
 	wantSingle := &DomainTransfer{
-		ID:                361,
-		DomainID:          182245,
-		RegistrantID:      2715,
+		ID:                int64(361),
+		DomainID:          int64(182245),
+		RegistrantID:      int64(2715),
 		State:             "transferring",
 		AutoRenew:         false,
 		WhoisPrivacy:      false,

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -108,10 +108,10 @@ func TestRegistrarService_RegisterDomain(t *testing.T) {
 	}
 
 	registration := registrationResponse.Data
-	if want, got := 1, registration.ID; want != got {
+	if want, got := int64(1), registration.ID; want != got {
 		t.Fatalf("Registrar.RegisterDomain() returned ID expected to be `%v`, got `%v`", want, got)
 	}
-	if want, got := 999, registration.DomainID; want != got {
+	if want, got := int64(999), registration.DomainID; want != got {
 		t.Fatalf("Registrar.RegisterDomain() returned DomainID expected to be `%v`, got `%v`", want, got)
 	}
 }


### PR DESCRIPTION
This PR fixes the type of some ID fields in `DomainRegistration` that are `int64` elsewhere.

Please, be aware that this could be considered a breaking change.