### PR TITLE
Add support for key-data interface creating delegation signer records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### main
 
+- CHANGED: Updated Tld and DelegationSignerRecord types to support DS record key-data interface (dnsimple/dnsimple-go#107)
+
 #### 0.70.1
 
 - DEPRECATED: Registrar.GetDomainPremiumPrice() has been deprecated, use Registrar.GetDomainPrices() instead.

--- a/dnsimple/domains_delegation_signer_records.go
+++ b/dnsimple/domains_delegation_signer_records.go
@@ -10,9 +10,10 @@ type DelegationSignerRecord struct {
 	ID         int64  `json:"id,omitempty"`
 	DomainID   int64  `json:"domain_id,omitempty"`
 	Algorithm  string `json:"algorithm"`
-	Digest     string `json:"digest"`
-	DigestType string `json:"digest_type"`
-	Keytag     string `json:"keytag"`
+	Digest     string `json:"digest,omitempty"`
+	DigestType string `json:"digest_type,omitempty"`
+	Keytag     string `json:"keytag,omitempty"`
+	PublicKey  string `json:"public_key,omitempty"`
 	CreatedAt  string `json:"created_at,omitempty"`
 	UpdatedAt  string `json:"updated_at,omitempty"`
 }

--- a/dnsimple/domains_delegation_signer_records_test.go
+++ b/dnsimple/domains_delegation_signer_records_test.go
@@ -134,6 +134,7 @@ func TestDomainsService_GetDelegationSignerRecord(t *testing.T) {
 		DigestType: "2",
 		Digest:     "C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F",
 		Keytag:     "44620",
+		PublicKey:  "",
 		CreatedAt:  "2017-03-03T13:49:58Z",
 		UpdatedAt:  "2017-03-03T13:49:58Z"}
 

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -23,6 +23,7 @@ type Tld struct {
 	RegistrationEnabled bool   `json:"registration_enabled"`
 	RenewalEnabled      bool   `json:"renewal_enabled"`
 	TransferEnabled     bool   `json:"transfer_enabled"`
+	DnssecInterfaceType string `json:"dnssec_interface_type"`
 }
 
 // TldExtendedAttribute represents an extended attributes supported or required

--- a/dnsimple/tlds_test.go
+++ b/dnsimple/tlds_test.go
@@ -100,8 +100,26 @@ func TestTldsService_GetTld(t *testing.T) {
 	if want, got := "com", tld.Tld; want != got {
 		t.Fatalf("Tlds.GetTlds() returned Tld expected to be `%v`, got `%v`", want, got)
 	}
+	if want, got := 1, tld.TldType; want != got {
+		t.Fatalf("Tlds.GetTlds() returned Tld.TldType expected to be `%v`, got `%v`", want, got)
+	}
+	if want, got := true, tld.WhoisPrivacy; want != got {
+		t.Fatalf("Tlds.GetTlds() returned Tld.WhoisPrivacy expected to be `%v`, got `%v`", want, got)
+	}
+	if want, got := false, tld.AutoRenewOnly; want != got {
+		t.Fatalf("Tlds.GetTlds() returned Tld.AutoRenewOnly expected to be `%v`, got `%v`", want, got)
+	}
 	if want, got := 1, tld.MinimumRegistration; want != got {
-		t.Fatalf("Tlds.GetTlds() returned Tld expected to be `%v`, got `%v`", want, got)
+		t.Fatalf("Tlds.GetTlds() returned Tld.MinimumRegistration expected to be `%v`, got `%v`", want, got)
+	}
+	if want, got := true, tld.RegistrationEnabled; want != got {
+		t.Fatalf("Tlds.GetTlds() returned Tld.RegistrationEnabled expected to be `%v`, got `%v`", want, got)
+	}
+	if want, got := true, tld.RenewalEnabled; want != got {
+		t.Fatalf("Tlds.GetTlds() returned Tld.RenewalEnabled expected to be `%v`, got `%v`", want, got)
+	}
+	if want, got := true, tld.TransferEnabled; want != got {
+		t.Fatalf("Tlds.GetTlds() returned Tld.TransferEnabled expected to be `%v`, got `%v`", want, got)
 	}
 	if want, got := "ds", tld.DnssecInterfaceType; want != got {
 		t.Fatalf("Tlds.GetTlds() returned Tld.DnssecInterfaceType expected to be `%v`, got `%v`", want, got)

--- a/dnsimple/tlds_test.go
+++ b/dnsimple/tlds_test.go
@@ -103,6 +103,9 @@ func TestTldsService_GetTld(t *testing.T) {
 	if want, got := 1, tld.MinimumRegistration; want != got {
 		t.Fatalf("Tlds.GetTlds() returned Tld expected to be `%v`, got `%v`", want, got)
 	}
+	if want, got := "ds", tld.DnssecInterfaceType; want != got {
+		t.Fatalf("Tlds.GetTlds() returned Tld.DnssecInterfaceType expected to be `%v`, got `%v`", want, got)
+	}
 }
 
 func TestTldsService_GetTldExtendedAttributes(t *testing.T) {

--- a/fixtures.http/api/createDelegationSignerRecord/created.http
+++ b/fixtures.http/api/createDelegationSignerRecord/created.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}
+{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","public_key":null,"created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}

--- a/fixtures.http/api/getDelegationSignerRecord/success.http
+++ b/fixtures.http/api/getDelegationSignerRecord/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}
+{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}

--- a/fixtures.http/api/getTld/success.http
+++ b/fixtures.http/api/getTld/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}}
+{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"ds"}}

--- a/fixtures.http/api/listDelegationSignerRecords/success.http
+++ b/fixtures.http/api/listDelegationSignerRecords/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}
+{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/fixtures.http/api/listTlds/success.http
+++ b/fixtures.http/api/listTlds/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}
+{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false,"dnssec_interface_type":"ds"},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"key"}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}


### PR DESCRIPTION
This PR:
* Updates the fixtures from [dnsimple-developer repo](https://github.com/dnsimple/dnsimple-developer/tree/main/fixtures/v2/api) to reflect the latest changes to our DNSSEC-related APIs.
* Updates affected type definitions.

I was able to verify the changes by enabling DNSSEC on one of our testing .BE domains.