### PR TITLE
Fixes the missing certificate id from the certificate purchase struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- FIXED: When purchasing a certificate the certificate id is populated now (CertificatePurchase)
+
 ## 0.71.0
 
 - CHANGED: Updated Tld and DelegationSignerRecord types to support DS record key-data interface (dnsimple/dnsimple-go#107)

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -43,7 +43,7 @@ type CertificateBundle struct {
 // CertificatePurchase represents a Certificate Purchase in DNSimple.
 type CertificatePurchase struct {
 	ID            int64  `json:"id,omitempty"`
-	CertificateID int64  `json:"new_certificate_id,omitempty"`
+	CertificateID int64  `json:"certificate_id,omitempty"`
 	State         string `json:"state,omitempty"`
 	AutoRenew     bool   `json:"auto_renew,omitempty"`
 	CreatedAt     string `json:"created_at,omitempty"`

--- a/dnsimple/certificates_test.go
+++ b/dnsimple/certificates_test.go
@@ -204,6 +204,9 @@ func TestCertificates_LetsencryptPurchase(t *testing.T) {
 	if want, got := int64(101967), certificatePurchase.ID; want != got {
 		t.Fatalf("Certificates.PurchaseLetsencryptCertificate() returned ID expected to be `%v`, got `%v`", want, got)
 	}
+	if want, got := int64(101967), certificatePurchase.CertificateID; want != got {
+		t.Fatalf("Certificates.PurchaseLetsencryptCertificate() returning certificate ID expected to be `%v`, got `%v`", want, got)
+	}
 }
 
 func TestCertificates_LetsencryptPurchaseWithAttributes(t *testing.T) {


### PR DESCRIPTION
This PR fixes the issue in where the certificate id was not picked up when purchasing a certificate