### PR TITLE
No longer require `contact_id` to purchase LetsEncrypt certificates

### DIFF
--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -17,6 +17,7 @@ type CertificatesService struct {
 type Certificate struct {
 	ID                  int64    `json:"id,omitempty"`
 	DomainID            int64    `json:"domain_id,omitempty"`
+    // Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
 	ContactID           int64    `json:"contact_id,omitempty"`
 	CommonName          string   `json:"common_name,omitempty"`
 	AlternateNames      []string `json:"alternate_names,omitempty"`
@@ -63,6 +64,7 @@ type CertificateRenewal struct {
 
 // LetsencryptCertificateAttributes is a set of attributes to purchase a Let's Encrypt certificate.
 type LetsencryptCertificateAttributes struct {
+    // Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
 	ContactID      int64    `json:"contact_id,omitempty"`
 	Name           string   `json:"name,omitempty"`
 	AutoRenew      bool     `json:"auto_renew,omitempty"`

--- a/dnsimple/certificates_test.go
+++ b/dnsimple/certificates_test.go
@@ -186,14 +186,14 @@ func TestCertificates_LetsencryptPurchase(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"contact_id": float64(100)}
+		want := map[string]interface{}{}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		_, _ = io.Copy(w, httpResponse.Body)
 	})
 
-	certificateAttributes := LetsencryptCertificateAttributes{ContactID: 100}
+	certificateAttributes := LetsencryptCertificateAttributes{}
 
 	certificateResponse, err := client.Certificates.PurchaseLetsencryptCertificate(context.Background(), "1010", "bingo.pizza", certificateAttributes)
 	if err != nil {
@@ -219,14 +219,14 @@ func TestCertificates_LetsencryptPurchaseWithAttributes(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"contact_id": float64(100), "name": "www", "auto_renew": true, "alternate_names": []interface{}{"api.example.com", "status.example.com"}}
+		want := map[string]interface{}{"name": "www", "auto_renew": true, "alternate_names": []interface{}{"api.example.com", "status.example.com"}}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		_, _ = io.Copy(w, httpResponse.Body)
 	})
 
-	certificateAttributes := LetsencryptCertificateAttributes{ContactID: 100, Name: "www", AutoRenew: true, AlternateNames: []string{"api.example.com", "status.example.com"}}
+	certificateAttributes := LetsencryptCertificateAttributes{Name: "www", AutoRenew: true, AlternateNames: []string{"api.example.com", "status.example.com"}}
 
 	_, err := client.Certificates.PurchaseLetsencryptCertificate(context.Background(), "1010", "example.com", certificateAttributes)
 	if err != nil {


### PR DESCRIPTION
We are flagging 2 attributes as deprecated/obsolete:
- `LetsencryptCertificateAttributes.ContactID`
- `Certificate.ContactID`

Tests have been updated to reflect deprecations.