### PR TITLE
Update Golang support according to the Release Policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.13"
-          - "1.14"
-          - "1.15"
-          - "1.16"
-          - "1.17"
           - "1.18"
           - "1.19"
-          # - tip disabled as not supported in GH Actions
-          # See: https://github.com/actions/setup-go/issues/21
+          # Only support last 2 versions (https://go.dev/doc/devel/release#policy)
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 - NEW: Expose AttributeErrors in ErrorResponse for getting detailed information about validation errors
+- CHANGED: Support only last two golang versions: 1.18 and 1.19 according Golang Release Policy.
 
 ## 0.80.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,18 @@
 module github.com/dnsimple/dnsimple-go
 
-go 1.13
+go 1.18
 
 require (
 	github.com/google/go-querystring v1.1.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e // indirect
+	google.golang.org/appengine v1.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,7 +23,6 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
This PR matches the version support that Golang provides, [only considering the last 2 releases](https://go.dev/doc/devel/release#policy):

* Updating the build matrix for 1.19 and 1.18
* Use 1.18 in go.mod as [minimum go version](https://go.dev/doc/modules/gomod-ref#go)