### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## main
+## 1.0.0
 
 - NEW: Expose AttributeErrors in ErrorResponse for getting detailed information about validation errors
 - CHANGED: Support only last two golang versions: 1.18 and 1.19 according Golang Release Policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - NEW: Expose AttributeErrors in ErrorResponse for getting detailed information about validation errors
 - CHANGED: Support only last two golang versions: 1.18 and 1.19 according Golang Release Policy.
+- CHANGED: Use testify/assert instead of stdlib
 
 ## 0.80.0
 

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -25,7 +25,7 @@ const (
 	// This is a pro-forma convention given that Go dependencies
 	// tends to be fetched directly from the repo.
 	// It is also used in the user-agent identify the client.
-	Version = "0.80.0"
+	Version = "1.0.0"
 
 	// defaultBaseURL to the DNSimple production API.
 	defaultBaseURL = "https://api.dnsimple.com"


### PR DESCRIPTION
This PR cuts a release for 1.0.0

Is a major bump because we are starting to support Golang 1.18 and 1.19 only following the Golang Release Policies