### PR TITLE
Implement signature_algorithm parameter for Let's Encrypt APIs

### DIFF
--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -65,10 +65,11 @@ type CertificateRenewal struct {
 // LetsencryptCertificateAttributes is a set of attributes to purchase a Let's Encrypt certificate.
 type LetsencryptCertificateAttributes struct {
     // Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
-	ContactID      int64    `json:"contact_id,omitempty"`
-	Name           string   `json:"name,omitempty"`
-	AutoRenew      bool     `json:"auto_renew,omitempty"`
-	AlternateNames []string `json:"alternate_names,omitempty"`
+	ContactID          int64    `json:"contact_id,omitempty"`
+	Name               string   `json:"name,omitempty"`
+	AutoRenew          bool     `json:"auto_renew,omitempty"`
+	AlternateNames     []string `json:"alternate_names,omitempty"`
+	SignatureAlgorithm string `json:"signature_algorithm,omitempty"`
 }
 
 func certificatePath(accountID, domainIdentifier string, certificateID int64) (path string) {

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -69,7 +69,7 @@ type LetsencryptCertificateAttributes struct {
 	Name               string   `json:"name,omitempty"`
 	AutoRenew          bool     `json:"auto_renew,omitempty"`
 	AlternateNames     []string `json:"alternate_names,omitempty"`
-	SignatureAlgorithm string `json:"signature_algorithm,omitempty"`
+	SignatureAlgorithm string   `json:"signature_algorithm,omitempty"`
 }
 
 func certificatePath(accountID, domainIdentifier string, certificateID int64) (path string) {

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -15,9 +15,9 @@ type CertificatesService struct {
 
 // Certificate represents a Certificate in DNSimple.
 type Certificate struct {
-	ID                  int64    `json:"id,omitempty"`
-	DomainID            int64    `json:"domain_id,omitempty"`
-    // Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
+	ID       int64 `json:"id,omitempty"`
+	DomainID int64 `json:"domain_id,omitempty"`
+	// Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
 	ContactID           int64    `json:"contact_id,omitempty"`
 	CommonName          string   `json:"common_name,omitempty"`
 	AlternateNames      []string `json:"alternate_names,omitempty"`
@@ -64,7 +64,7 @@ type CertificateRenewal struct {
 
 // LetsencryptCertificateAttributes is a set of attributes to purchase a Let's Encrypt certificate.
 type LetsencryptCertificateAttributes struct {
-    // Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
+	// Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
 	ContactID          int64    `json:"contact_id,omitempty"`
 	Name               string   `json:"name,omitempty"`
 	AutoRenew          bool     `json:"auto_renew,omitempty"`

--- a/dnsimple/certificates_test.go
+++ b/dnsimple/certificates_test.go
@@ -253,14 +253,14 @@ func TestCertificates_LetsencryptPurchaseRenewalWithAttributes(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"auto_renew": true}
+		want := map[string]interface{}{"auto_renew": true, "signature_algorithm": "RSA"}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		_, _ = io.Copy(w, httpResponse.Body)
 	})
 
-	certificateAttributes := LetsencryptCertificateAttributes{AutoRenew: true}
+	certificateAttributes := LetsencryptCertificateAttributes{AutoRenew: true, SignatureAlgorithm: "RSA"}
 
 	certificateRenewalResponse, err := client.Certificates.PurchaseLetsencryptCertificateRenewal(context.Background(), "1010", "bingo.pizza", 101967, certificateAttributes)
 

--- a/dnsimple/certificates_test.go
+++ b/dnsimple/certificates_test.go
@@ -181,14 +181,14 @@ func TestCertificates_LetsencryptPurchaseWithAttributes(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"name": "www", "auto_renew": true, "alternate_names": []interface{}{"api.example.com", "status.example.com"}}
+		want := map[string]interface{}{"name": "www", "auto_renew": true, "alternate_names": []interface{}{"api.example.com", "status.example.com"}, "signature_algorithm": "RSA"}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		_, _ = io.Copy(w, httpResponse.Body)
 	})
 
-	certificateAttributes := LetsencryptCertificateAttributes{Name: "www", AutoRenew: true, AlternateNames: []string{"api.example.com", "status.example.com"}}
+	certificateAttributes := LetsencryptCertificateAttributes{Name: "www", AutoRenew: true, AlternateNames: []string{"api.example.com", "status.example.com"}, SignatureAlgorithm: "RSA"}
 
 	_, err := client.Certificates.PurchaseLetsencryptCertificate(context.Background(), "1010", "example.com", certificateAttributes)
 


### PR DESCRIPTION
Add the `signature_algorithm` parameter for PurchaseLetsencryptCertificate and PurchaseLetsencryptCertificateRenewal APIs.