### PR TITLE
Validate path parameters for endpoints of Domains and Certificates APIs

### DIFF
--- a/dnsimple/certificates_test.go
+++ b/dnsimple/certificates_test.go
@@ -10,9 +10,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCertificatesPath(t *testing.T) {
+	t.Run("empty account id", func(t *testing.T) {
+		path, err := certificatesPath("", "example.com")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("empty domain identifier", func(t *testing.T) {
+		path, err := certificatesPath("1010", "")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		path, err := certificatesPath("1010", "example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "/1010/domains/example.com/certificates", path)
+	})
+}
+
 func TestCertificatePath(t *testing.T) {
-	assert.Equal(t, "/1010/domains/example.com/certificates", certificatePath("1010", "example.com", 0))
-	assert.Equal(t, "/1010/domains/example.com/certificates/2", certificatePath("1010", "example.com", 2))
+	path, err := certificatePath("1010", "example.com", 123)
+	assert.NoError(t, err)
+	assert.Equal(t, "/1010/domains/example.com/certificates/123", path)
 }
 
 func TestCertificatesService_ListCertificates(t *testing.T) {

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -2,6 +2,7 @@ package dnsimple
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -29,12 +30,25 @@ type Domain struct {
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
-func domainPath(accountID string, domainIdentifier string) (path string) {
-	path = fmt.Sprintf("/%v/domains", accountID)
-	if domainIdentifier != "" {
-		path += fmt.Sprintf("/%v", domainIdentifier)
+func domainPath(accountID string, domainIdentifier string) (string, error) {
+	basePath, err := domainsPath(accountID)
+	if err != nil {
+		return "", err
 	}
-	return
+
+	if domainIdentifier == "" {
+		return "", errors.New("domain identifier parameter should not be empty")
+	}
+
+	return fmt.Sprintf("%v/%v", basePath, domainIdentifier), nil
+}
+
+func domainsPath(accountID string) (string, error) {
+	if accountID == "" {
+		return "", errors.New("account parameter should not be empty")
+	}
+
+	return fmt.Sprintf("/%v/domains", accountID), nil
 }
 
 // DomainResponse represents a response from an API method that returns a Domain struct.
@@ -65,10 +79,16 @@ type DomainListOptions struct {
 //
 // See https://developer.dnsimple.com/v2/domains/#list
 func (s *DomainsService) ListDomains(ctx context.Context, accountID string, options *DomainListOptions) (*DomainsResponse, error) {
-	path := versioned(domainPath(accountID, ""))
+	path, err := domainsPath(accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	domainsResponse := &DomainsResponse{}
 
-	path, err := addURLQueryOptions(path, options)
+	path, err = addURLQueryOptions(path, options)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +106,13 @@ func (s *DomainsService) ListDomains(ctx context.Context, accountID string, opti
 //
 // See https://developer.dnsimple.com/v2/domains/#create
 func (s *DomainsService) CreateDomain(ctx context.Context, accountID string, domainAttributes Domain) (*DomainResponse, error) {
-	path := versioned(domainPath(accountID, ""))
+	path, err := domainsPath(accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	domainResponse := &DomainResponse{}
 
 	resp, err := s.client.post(ctx, path, domainAttributes, domainResponse)
@@ -102,7 +128,13 @@ func (s *DomainsService) CreateDomain(ctx context.Context, accountID string, dom
 //
 // See https://developer.dnsimple.com/v2/domains/#get
 func (s *DomainsService) GetDomain(ctx context.Context, accountID string, domainIdentifier string) (*DomainResponse, error) {
-	path := versioned(domainPath(accountID, domainIdentifier))
+	path, err := domainPath(accountID, domainIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	domainResponse := &DomainResponse{}
 
 	resp, err := s.client.get(ctx, path, domainResponse)
@@ -118,7 +150,13 @@ func (s *DomainsService) GetDomain(ctx context.Context, accountID string, domain
 //
 // See https://developer.dnsimple.com/v2/domains/#delete
 func (s *DomainsService) DeleteDomain(ctx context.Context, accountID string, domainIdentifier string) (*DomainResponse, error) {
-	path := versioned(domainPath(accountID, domainIdentifier))
+	path, err := domainPath(accountID, domainIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	domainResponse := &DomainResponse{}
 
 	resp, err := s.client.delete(ctx, path, nil, nil)

--- a/dnsimple/domains_collaborators_test.go
+++ b/dnsimple/domains_collaborators_test.go
@@ -10,9 +10,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCollaboratorsPath(t *testing.T) {
+	t.Run("empty account id", func(t *testing.T) {
+		path, err := collaboratorsPath("", "example.com")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("empty domain identifier", func(t *testing.T) {
+		path, err := collaboratorsPath("1010", "")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		path, err := collaboratorsPath("1010", "example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "/1010/domains/example.com/collaborators", path)
+	})
+}
+
 func TestCollaboratorPath(t *testing.T) {
-	assert.Equal(t, "/1010/domains/example.com/collaborators", collaboratorPath("1010", "example.com", 0))
-	assert.Equal(t, "/1010/domains/example.com/collaborators/2", collaboratorPath("1010", "example.com", 2))
+	path, err := collaboratorPath("1010", "example.com", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, "/1010/domains/example.com/collaborators/2", path)
 }
 
 func TestDomainsService_ListCollaborators(t *testing.T) {

--- a/dnsimple/domains_delegation_signer_records.go
+++ b/dnsimple/domains_delegation_signer_records.go
@@ -18,12 +18,22 @@ type DelegationSignerRecord struct {
 	UpdatedAt  string `json:"updated_at,omitempty"`
 }
 
-func delegationSignerRecordPath(accountID string, domainIdentifier string, dsRecordID int64) (path string) {
-	path = fmt.Sprintf("%v/ds_records", domainPath(accountID, domainIdentifier))
-	if dsRecordID != 0 {
-		path += fmt.Sprintf("/%v", dsRecordID)
+func delegationSignerRecordsPath(accountID string, domainIdentifier string) (string, error) {
+	basePath, err := domainPath(accountID, domainIdentifier)
+	if err != nil {
+		return "", err
 	}
-	return
+
+	return fmt.Sprintf("%v/ds_records", basePath), nil
+}
+
+func delegationSignerRecordPath(accountID string, domainIdentifier string, dsRecordID int64) (string, error) {
+	basePath, err := delegationSignerRecordsPath(accountID, domainIdentifier)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v/%v", basePath, dsRecordID), nil
 }
 
 // DelegationSignerRecordResponse represents a response from an API method that returns a DelegationSignerRecord struct.
@@ -42,13 +52,19 @@ type DelegationSignerRecordsResponse struct {
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-list
 func (s *DomainsService) ListDelegationSignerRecords(ctx context.Context, accountID string, domainIdentifier string, options *ListOptions) (*DelegationSignerRecordsResponse, error) {
-	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
-	dsRecordsResponse := &DelegationSignerRecordsResponse{}
-
-	path, err := addURLQueryOptions(path, options)
+	path, err := delegationSignerRecordsPath(accountID, domainIdentifier)
 	if err != nil {
 		return nil, err
 	}
+
+	path = versioned(path)
+
+	path, err = addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	dsRecordsResponse := &DelegationSignerRecordsResponse{}
 
 	resp, err := s.client.get(ctx, path, dsRecordsResponse)
 	if err != nil {
@@ -63,7 +79,13 @@ func (s *DomainsService) ListDelegationSignerRecords(ctx context.Context, accoun
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-create
 func (s *DomainsService) CreateDelegationSignerRecord(ctx context.Context, accountID string, domainIdentifier string, dsRecordAttributes DelegationSignerRecord) (*DelegationSignerRecordResponse, error) {
-	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
+	path, err := delegationSignerRecordsPath(accountID, domainIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	dsRecordResponse := &DelegationSignerRecordResponse{}
 
 	resp, err := s.client.post(ctx, path, dsRecordAttributes, dsRecordResponse)
@@ -79,7 +101,13 @@ func (s *DomainsService) CreateDelegationSignerRecord(ctx context.Context, accou
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-get
 func (s *DomainsService) GetDelegationSignerRecord(ctx context.Context, accountID string, domainIdentifier string, dsRecordID int64) (*DelegationSignerRecordResponse, error) {
-	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
+	path, err := delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	dsRecordResponse := &DelegationSignerRecordResponse{}
 
 	resp, err := s.client.get(ctx, path, dsRecordResponse)
@@ -96,7 +124,13 @@ func (s *DomainsService) GetDelegationSignerRecord(ctx context.Context, accountI
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-delete
 func (s *DomainsService) DeleteDelegationSignerRecord(ctx context.Context, accountID string, domainIdentifier string, dsRecordID int64) (*DelegationSignerRecordResponse, error) {
-	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
+	path, err := delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	dsRecordResponse := &DelegationSignerRecordResponse{}
 
 	resp, err := s.client.delete(ctx, path, nil, nil)

--- a/dnsimple/domains_delegation_signer_records_test.go
+++ b/dnsimple/domains_delegation_signer_records_test.go
@@ -10,9 +10,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDelegationSignerRecordsPath(t *testing.T) {
+	t.Run("empty account id", func(t *testing.T) {
+		path, err := delegationSignerRecordsPath("", "example.com")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("empty domain identifier", func(t *testing.T) {
+		path, err := delegationSignerRecordsPath("1010", "")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		path, err := delegationSignerRecordsPath("1010", "example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "/1010/domains/example.com/ds_records", path)
+	})
+}
+
 func TestDelegationSignerRecordPath(t *testing.T) {
-	assert.Equal(t, "/1010/domains/example.com/ds_records", delegationSignerRecordPath("1010", "example.com", 0))
-	assert.Equal(t, "/1010/domains/example.com/ds_records/2", delegationSignerRecordPath("1010", "example.com", 2))
+	path, err := delegationSignerRecordPath("1010", "example.com", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, "/1010/domains/example.com/ds_records/2", path)
 }
 
 func TestDomainsService_ListDelegationSignerRecords(t *testing.T) {

--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -10,9 +10,13 @@ type Dnssec struct {
 	Enabled bool `json:"enabled"`
 }
 
-func dnssecPath(accountID string, domainIdentifier string) (path string) {
-	path = fmt.Sprintf("%v/dnssec", domainPath(accountID, domainIdentifier))
-	return
+func dnssecPath(accountID string, domainIdentifier string) (string, error) {
+	basePath, err := domainPath(accountID, domainIdentifier)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v/dnssec", basePath), nil
 }
 
 // DnssecResponse represents a response from an API method that returns a Dnssec struct.
@@ -25,7 +29,13 @@ type DnssecResponse struct {
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#enableDomainDnssec
 func (s *DomainsService) EnableDnssec(ctx context.Context, accountID string, domainIdentifier string) (*DnssecResponse, error) {
-	path := versioned(dnssecPath(accountID, domainIdentifier))
+	path, err := dnssecPath(accountID, domainIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	dnssecResponse := &DnssecResponse{}
 
 	resp, err := s.client.post(ctx, path, dnssecResponse, nil)
@@ -41,7 +51,13 @@ func (s *DomainsService) EnableDnssec(ctx context.Context, accountID string, dom
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#disableDomainDnssec
 func (s *DomainsService) DisableDnssec(ctx context.Context, accountID string, domainIdentifier string) (*DnssecResponse, error) {
-	path := versioned(dnssecPath(accountID, domainIdentifier))
+	path, err := dnssecPath(accountID, domainIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	dnssecResponse := &DnssecResponse{}
 
 	resp, err := s.client.delete(ctx, path, dnssecResponse, nil)
@@ -57,7 +73,13 @@ func (s *DomainsService) DisableDnssec(ctx context.Context, accountID string, do
 //
 // See https://developer.dnsimple.com/v2/domains/dnssec/#getDomainDnssec
 func (s *DomainsService) GetDnssec(ctx context.Context, accountID string, domainIdentifier string) (*DnssecResponse, error) {
-	path := versioned(dnssecPath(accountID, domainIdentifier))
+	path, err := dnssecPath(accountID, domainIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	dnssecResponse := &DnssecResponse{}
 
 	resp, err := s.client.get(ctx, path, dnssecResponse)

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -10,7 +10,23 @@ import (
 )
 
 func TestDnssecPath(t *testing.T) {
-	assert.Equal(t, "/1010/domains/example.com/dnssec", dnssecPath("1010", "example.com"))
+	t.Run("empty account id", func(t *testing.T) {
+		path, err := dnssecPath("", "example.com")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("empty domain identifier", func(t *testing.T) {
+		path, err := dnssecPath("1010", "")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		path, err := dnssecPath("1010", "example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "/1010/domains/example.com/dnssec", path)
+	})
 }
 
 func TestDomainsService_EnableDnssec(t *testing.T) {

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -15,12 +15,22 @@ type EmailForward struct {
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-func emailForwardPath(accountID string, domainIdentifier string, forwardID int64) (path string) {
-	path = fmt.Sprintf("%v/email_forwards", domainPath(accountID, domainIdentifier))
-	if forwardID != 0 {
-		path += fmt.Sprintf("/%v", forwardID)
+func emailForwardsPath(accountID string, domainIdentifier string) (string, error) {
+	basePath, err := domainPath(accountID, domainIdentifier)
+	if err != nil {
+		return "", err
 	}
-	return
+
+	return fmt.Sprintf("%v/email_forwards", basePath), nil
+}
+
+func emailForwardPath(accountID string, domainIdentifier string, forwardID int64) (string, error) {
+	basePath, err := emailForwardsPath(accountID, domainIdentifier)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v/%v", basePath, forwardID), nil
 }
 
 // EmailForwardResponse represents a response from an API method that returns an EmailForward struct.
@@ -39,13 +49,19 @@ type EmailForwardsResponse struct {
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#list
 func (s *DomainsService) ListEmailForwards(ctx context.Context, accountID string, domainIdentifier string, options *ListOptions) (*EmailForwardsResponse, error) {
-	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
-	forwardsResponse := &EmailForwardsResponse{}
-
-	path, err := addURLQueryOptions(path, options)
+	path, err := emailForwardsPath(accountID, domainIdentifier)
 	if err != nil {
 		return nil, err
 	}
+
+	path = versioned(path)
+
+	path, err = addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	forwardsResponse := &EmailForwardsResponse{}
 
 	resp, err := s.client.get(ctx, path, forwardsResponse)
 	if err != nil {
@@ -60,7 +76,13 @@ func (s *DomainsService) ListEmailForwards(ctx context.Context, accountID string
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#create
 func (s *DomainsService) CreateEmailForward(ctx context.Context, accountID string, domainIdentifier string, forwardAttributes EmailForward) (*EmailForwardResponse, error) {
-	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
+	path, err := emailForwardsPath(accountID, domainIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	forwardResponse := &EmailForwardResponse{}
 
 	resp, err := s.client.post(ctx, path, forwardAttributes, forwardResponse)
@@ -76,7 +98,13 @@ func (s *DomainsService) CreateEmailForward(ctx context.Context, accountID strin
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#get
 func (s *DomainsService) GetEmailForward(ctx context.Context, accountID string, domainIdentifier string, forwardID int64) (*EmailForwardResponse, error) {
-	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
+	path, err := emailForwardPath(accountID, domainIdentifier, forwardID)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	forwardResponse := &EmailForwardResponse{}
 
 	resp, err := s.client.get(ctx, path, forwardResponse)
@@ -92,7 +120,13 @@ func (s *DomainsService) GetEmailForward(ctx context.Context, accountID string, 
 //
 // See https://developer.dnsimple.com/v2/domains/email-forwards/#delete
 func (s *DomainsService) DeleteEmailForward(ctx context.Context, accountID string, domainIdentifier string, forwardID int64) (*EmailForwardResponse, error) {
-	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
+	path, err := emailForwardPath(accountID, domainIdentifier, forwardID)
+	if err != nil {
+		return nil, err
+	}
+
+	path = versioned(path)
+
 	forwardResponse := &EmailForwardResponse{}
 
 	resp, err := s.client.delete(ctx, path, nil, nil)

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -13,9 +13,30 @@ import (
 
 var regexpEmail = regexp.MustCompile(`.+@.+`)
 
+func TestEmailForwardsPath(t *testing.T) {
+	t.Run("empty account id", func(t *testing.T) {
+		path, err := emailForwardsPath("", "example.com")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("empty domain identifier", func(t *testing.T) {
+		path, err := emailForwardsPath("1010", "")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		path, err := emailForwardsPath("1010", "example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "/1010/domains/example.com/email_forwards", path)
+	})
+}
+
 func TestEmailForwardPath(t *testing.T) {
-	assert.Equal(t, "/1010/domains/example.com/email_forwards", emailForwardPath("1010", "example.com", 0))
-	assert.Equal(t, "/1010/domains/example.com/email_forwards/2", emailForwardPath("1010", "example.com", 2))
+	path, err := emailForwardPath("1010", "example.com", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, "/1010/domains/example.com/email_forwards/2", path)
 }
 
 func TestDomainsService_EmailForwardsList(t *testing.T) {

--- a/dnsimple/domains_pushes_test.go
+++ b/dnsimple/domains_pushes_test.go
@@ -10,9 +10,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDomainPushesPath(t *testing.T) {
+	t.Run("empty account id", func(t *testing.T) {
+		path, err := pushesPath("")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		path, err := pushesPath("1010")
+		assert.NoError(t, err)
+		assert.Equal(t, "/1010/pushes", path)
+	})
+}
+
 func TestDomainPushPath(t *testing.T) {
-	assert.Equal(t, "/1010/pushes", domainPushPath("1010", 0))
-	assert.Equal(t, "/1010/pushes/1", domainPushPath("1010", 1))
+	path, err := pushPath("1010", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "/1010/pushes/1", path)
 }
 
 func TestDomainsService_InitiatePush(t *testing.T) {

--- a/dnsimple/domains_test.go
+++ b/dnsimple/domains_test.go
@@ -10,9 +10,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDomainsPath(t *testing.T) {
+	t.Run("empty account id", func(t *testing.T) {
+		path, err := domainsPath("")
+		assert.Error(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		path, err := domainsPath("1010")
+		assert.NoError(t, err)
+		assert.Equal(t, "/1010/domains", path)
+	})
+}
+
 func TestDomainPath(t *testing.T) {
-	assert.Equal(t, "/1010/domains", domainPath("1010", ""))
-	assert.Equal(t, "/1010/domains/example.com", domainPath("1010", "example.com"))
+	path, err := domainPath("1010", "example.com")
+	assert.NoError(t, err)
+	assert.Equal(t, "/1010/domains/example.com", path)
 }
 
 func TestDomainsService_ListDomains(t *testing.T) {

--- a/dnsimple/templates_domains.go
+++ b/dnsimple/templates_domains.go
@@ -2,6 +2,7 @@ package dnsimple
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -9,7 +10,17 @@ import (
 //
 // See https://developer.dnsimple.com/v2/templates/domains/#applyTemplateToDomain
 func (s *TemplatesService) ApplyTemplate(ctx context.Context, accountID string, templateIdentifier string, domainIdentifier string) (*TemplateResponse, error) {
-	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath(accountID, domainIdentifier), templateIdentifier))
+	if templateIdentifier == "" {
+		return nil, errors.New("empty path param")
+	}
+
+	domainPath, err := domainPath(accountID, domainIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath, templateIdentifier))
+
 	templateResponse := &TemplateResponse{}
 
 	resp, err := s.client.post(ctx, path, nil, nil)


### PR DESCRIPTION
This PR validates path parameters Domains and Certificates APIs endpoints, currently when string parameters like `accountID` or `domainIdentifier` are empty, call to wrong endpoints are made