### PR TITLE
Fix DisableDnssec and EnableDnssec response data deserialisation

### DIFF
--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -28,7 +28,7 @@ func (s *DomainsService) EnableDnssec(ctx context.Context, accountID string, dom
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &DnssecResponse{}
 
-	resp, err := s.client.post(ctx, path, dnssecResponse, nil)
+	resp, err := s.client.post(ctx, path, nil, dnssecResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (s *DomainsService) DisableDnssec(ctx context.Context, accountID string, do
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &DnssecResponse{}
 
-	resp, err := s.client.delete(ctx, path, dnssecResponse, nil)
+	resp, err := s.client.delete(ctx, path, nil, dnssecResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_dnssec.go
+++ b/dnsimple/domains_dnssec.go
@@ -44,7 +44,7 @@ func (s *DomainsService) DisableDnssec(ctx context.Context, accountID string, do
 	path := versioned(dnssecPath(accountID, domainIdentifier))
 	dnssecResponse := &DnssecResponse{}
 
-	resp, err := s.client.delete(ctx, path, nil, dnssecResponse)
+	resp, err := s.client.delete(ctx, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -51,9 +51,10 @@ func TestDomainsService_DisableDnssec(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Domains.DisableDnssec(context.Background(), accountID, "example.com")
+	res, err := client.Domains.DisableDnssec(context.Background(), accountID, "example.com")
 
 	assert.NoError(t, err)
+	assert.Equal(t, nil, res.Data)
 }
 
 func TestDomainsService_GetDnssec(t *testing.T) {

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -31,7 +31,7 @@ func TestDomainsService_EnableDnssec(t *testing.T) {
 	res, err := client.Domains.EnableDnssec(context.Background(), accountID, "example.com")
 
 	assert.NoError(t, err)
-	assert.Equal(t, &Dnssec{Enabled: false}, res.Data)
+	assert.Equal(t, &Dnssec{Enabled: true}, res.Data)
 }
 
 func TestDomainsService_DisableDnssec(t *testing.T) {

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -49,10 +49,9 @@ func TestDomainsService_DisableDnssec(t *testing.T) {
 
 	accountID := "1010"
 
-	res, err := client.Domains.DisableDnssec(context.Background(), accountID, "example.com")
+	_, err := client.Domains.DisableDnssec(context.Background(), accountID, "example.com")
 
 	assert.NoError(t, err)
-	assert.Equal(t, &Dnssec{Enabled: false}, res.Data)
 }
 
 func TestDomainsService_GetDnssec(t *testing.T) {

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -46,6 +46,7 @@ func TestDomainsService_DisableDnssec(t *testing.T) {
 		testHeaders(t, r)
 
 		w.WriteHeader(httpResponse.StatusCode)
+		_, _ = io.Copy(w, httpResponse.Body)
 	})
 
 	accountID := "1010"

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -24,6 +24,7 @@ func TestDomainsService_EnableDnssec(t *testing.T) {
 		testHeaders(t, r)
 
 		w.WriteHeader(httpResponse.StatusCode)
+		_, _ = io.Copy(w, httpResponse.Body)
 	})
 
 	accountID := "1010"

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -28,9 +28,10 @@ func TestDomainsService_EnableDnssec(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Domains.EnableDnssec(context.Background(), accountID, "example.com")
+	res, err := client.Domains.EnableDnssec(context.Background(), accountID, "example.com")
 
 	assert.NoError(t, err)
+	assert.Equal(t, &Dnssec{Enabled: false}, res.Data)
 }
 
 func TestDomainsService_DisableDnssec(t *testing.T) {
@@ -48,9 +49,10 @@ func TestDomainsService_DisableDnssec(t *testing.T) {
 
 	accountID := "1010"
 
-	_, err := client.Domains.DisableDnssec(context.Background(), accountID, "example.com")
+	res, err := client.Domains.DisableDnssec(context.Background(), accountID, "example.com")
 
 	assert.NoError(t, err)
+	assert.Equal(t, &Dnssec{Enabled: false}, res.Data)
 }
 
 func TestDomainsService_GetDnssec(t *testing.T) {

--- a/dnsimple/domains_dnssec_test.go
+++ b/dnsimple/domains_dnssec_test.go
@@ -53,8 +53,9 @@ func TestDomainsService_DisableDnssec(t *testing.T) {
 
 	res, err := client.Domains.DisableDnssec(context.Background(), accountID, "example.com")
 
-	assert.NoError(t, err)
-	assert.Equal(t, nil, res.Data)
+	if assert.NoError(t, err) {
+		assert.Nil(t, res.Data)
+	}
 }
 
 func TestDomainsService_GetDnssec(t *testing.T) {


### PR DESCRIPTION
Currently, the `response.Data` is nil due to passing arguments incorrectly.