### PR TITLE
Add support to activate and deactivate DNS services for a zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## main
+
+## 1.2.1 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `ActivateZoneDns` to activate DNS services (resolution) for a zone. (dnsimple/dnsimple-go#145)
+- NEW: Added `DeactivateZoneDns` to deactivate DNS services (resolution) for a zone. (dnsimple/dnsimple-go#145)
+
+IMPROVEMENTS:
+
+- `EmailForward` `From` is deprecated. Please use `AliasName` instead for creating email forwards. (dnsimple/dnsimple-go#145)
+- `EmailForward` `To` is deprecated. Please use `DestinationEmail` instead for creating email forwards. (dnsimple/dnsimple-go#145)
+
 ## 1.2.0
 
 - NEW: Support `GetDomainRegistration` and `GetDomainRenewal` APIs (dnsimple/dnsimple-go#132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
-- `EmailForward` `From` is deprecated. Please use `AliasName` instead for creating email forwards. (dnsimple/dnsimple-go#145)
+- `EmailForward` `From` is deprecated. Please use `AliasName` instead for creating email forwards, and `AliasEmail` when retrieving email forwards. (dnsimple/dnsimple-go#145)
 - `EmailForward` `To` is deprecated. Please use `DestinationEmail` instead for creating email forwards. (dnsimple/dnsimple-go#145)
 
 ## 1.2.0

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -7,16 +7,16 @@ import (
 
 // EmailForward represents an email forward in DNSimple.
 type EmailForward struct {
-	ID        int64  `json:"id,omitempty"`
-	DomainID  int64  `json:"domain_id,omitempty"`
+	ID       int64 `json:"id,omitempty"`
+	DomainID int64 `json:"domain_id,omitempty"`
 	// Deprecated: please use `AliasName` instead.
 	From      string `json:"from,omitempty"`
 	AliasName string `json:"alias_name,omitempty"`
 	// Deprecated: please use `DestinationEmail` instead.
-	To        string `json:"to,omitempty"`
+	To               string `json:"to,omitempty"`
 	DestinationEmail string `json:"destination_email,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	CreatedAt        string `json:"created_at,omitempty"`
+	UpdatedAt        string `json:"updated_at,omitempty"`
 }
 
 func emailForwardPath(accountID string, domainIdentifier string, forwardID int64) (path string) {

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -9,8 +9,9 @@ import (
 type EmailForward struct {
 	ID       int64 `json:"id,omitempty"`
 	DomainID int64 `json:"domain_id,omitempty"`
-	// Deprecated: please use `AliasName` instead.
+	// For requests, this field is deprecated, please use `AliasName` instead.
 	From      string `json:"from,omitempty"`
+	// WARNING: This is not set in responses, please use `From` instead.
 	AliasName string `json:"alias_name,omitempty"`
 	// Deprecated: please use `DestinationEmail` instead.
 	To               string `json:"to,omitempty"`

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -9,10 +9,12 @@ import (
 type EmailForward struct {
 	ID       int64 `json:"id,omitempty"`
 	DomainID int64 `json:"domain_id,omitempty"`
-	// For requests, this field is deprecated, please use `AliasName` instead.
-	From      string `json:"from,omitempty"`
-	// WARNING: This is not set in responses, please use `From` instead.
+	// Deprecated: for requests, please use `AliasName` instead; for responses, please use `AliasEmail` instead.
+	From string `json:"from,omitempty"`
+	// WARNING: This is not set in responses, please use `AliasEmail` instead.
 	AliasName string `json:"alias_name,omitempty"`
+	// WARNING: This is not used by requests, please use `AliasName` instead.
+	AliasEmail string `json:"alias_email,omitempty"`
 	// Deprecated: please use `DestinationEmail` instead.
 	To               string `json:"to,omitempty"`
 	DestinationEmail string `json:"destination_email,omitempty"`

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -9,8 +9,12 @@ import (
 type EmailForward struct {
 	ID        int64  `json:"id,omitempty"`
 	DomainID  int64  `json:"domain_id,omitempty"`
+	// Deprecated: please use `AliasName` instead.
 	From      string `json:"from,omitempty"`
+	AliasName string `json:"alias_name,omitempty"`
+	// Deprecated: please use `DestinationEmail` instead.
 	To        string `json:"to,omitempty"`
+	DestinationEmail string `json:"destination_email,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
 }

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -108,7 +108,9 @@ func TestDomainsService_GetEmailForward(t *testing.T) {
 		ID:        41872,
 		DomainID:  235146,
 		From:      "example@dnsimple.xyz",
+		AliasName: "example@dnsimple.xyz",
 		To:        "example@example.com",
+		DestinationEmail: "example@example.com",
 		CreatedAt: "2021-01-25T13:54:40Z",
 		UpdatedAt: "2021-01-25T13:54:40Z"}
 	assert.Equal(t, wantSingle, forward)

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -105,14 +105,14 @@ func TestDomainsService_GetEmailForward(t *testing.T) {
 	assert.NoError(t, err)
 	forward := forwardResponse.Data
 	wantSingle := &EmailForward{
-		ID:        41872,
-		DomainID:  235146,
-		From:      "example@dnsimple.xyz",
-		AliasName: "example@dnsimple.xyz",
-		To:        "example@example.com",
+		ID:               41872,
+		DomainID:         235146,
+		From:             "example@dnsimple.xyz",
+		AliasName:        "example@dnsimple.xyz",
+		To:               "example@example.com",
 		DestinationEmail: "example@example.com",
-		CreatedAt: "2021-01-25T13:54:40Z",
-		UpdatedAt: "2021-01-25T13:54:40Z"}
+		CreatedAt:        "2021-01-25T13:54:40Z",
+		UpdatedAt:        "2021-01-25T13:54:40Z"}
 	assert.Equal(t, wantSingle, forward)
 }
 

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -108,7 +108,7 @@ func TestDomainsService_GetEmailForward(t *testing.T) {
 		ID:               41872,
 		DomainID:         235146,
 		From:             "example@dnsimple.xyz",
-		AliasName:        "example@dnsimple.xyz",
+		AliasName:        "",
 		To:               "example@example.com",
 		DestinationEmail: "example@example.com",
 		CreatedAt:        "2021-01-25T13:54:40Z",

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -109,6 +109,7 @@ func TestDomainsService_GetEmailForward(t *testing.T) {
 		DomainID:         235146,
 		From:             "example@dnsimple.xyz",
 		AliasName:        "",
+		AliasEmail:       "example@dnsimple.xyz",
 		To:               "example@example.com",
 		DestinationEmail: "example@example.com",
 		CreatedAt:        "2021-01-25T13:54:40Z",

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -108,7 +108,7 @@ func (s *ZonesService) GetZoneFile(ctx context.Context, accountID string, zoneNa
 	return zoneFileResponse, nil
 }
 
-// ActivateDns activates DNS services for a zone.
+// ActivateZoneDns activates DNS services for a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#activateZoneService
 func (s *ZonesService) ActivateZoneDns(ctx context.Context, accountID string, zoneName string) (*ZoneResponse, error) {
@@ -124,7 +124,7 @@ func (s *ZonesService) ActivateZoneDns(ctx context.Context, accountID string, zo
 	return zoneResponse, nil
 }
 
-// DeactivateDns deactivates DNS services for a zone.
+// DeactivateZoneDns deactivates DNS services for a zone.
 //
 // See https://developer.dnsimple.com/v2/zones/#deactivateZoneService
 func (s *ZonesService) DeactivateZoneDns(ctx context.Context, accountID string, zoneName string) (*ZoneResponse, error) {

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -107,3 +107,35 @@ func (s *ZonesService) GetZoneFile(ctx context.Context, accountID string, zoneNa
 	zoneFileResponse.HTTPResponse = resp
 	return zoneFileResponse, nil
 }
+
+// ActivateDns activates DNS services for a zone.
+//
+// See https://developer.dnsimple.com/v2/zones/#activateZoneService
+func (s *ZonesService) ActivateZoneDns(ctx context.Context, accountID string, zoneName string) (*ZoneResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/zones/%v/activation", accountID, zoneName))
+	zoneResponse := &ZoneResponse{}
+
+	resp, err := s.client.put(ctx, path, nil, zoneResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	zoneResponse.HTTPResponse = resp
+	return zoneResponse, nil
+}
+
+// DeactivateDns deactivates DNS services for a zone.
+//
+// See https://developer.dnsimple.com/v2/zones/#deactivateZoneService
+func (s *ZonesService) DeactivateZoneDns(ctx context.Context, accountID string, zoneName string) (*ZoneResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/zones/%v/activation", accountID, zoneName))
+	zoneResponse := &ZoneResponse{}
+
+	resp, err := s.client.delete(ctx, path, nil, zoneResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	zoneResponse.HTTPResponse = resp
+	return zoneResponse, nil
+}

--- a/dnsimple/zones_test.go
+++ b/dnsimple/zones_test.go
@@ -114,3 +114,67 @@ func TestZonesService_GetZoneFile(t *testing.T) {
 	}
 	assert.Equal(t, wantSingle, zoneFile)
 }
+
+func TestZonesService_ActivateZoneDns(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/zones/example.com/activation", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/api/activateZoneService/success.http")
+
+		testMethod(t, r, "PUT")
+		testHeaders(t, r)
+
+		w.WriteHeader(httpResponse.StatusCode)
+		_, _ = io.Copy(w, httpResponse.Body)
+	})
+
+	accountID := "1010"
+	zoneName := "example.com"
+
+	zoneResponse, err := client.Zones.ActivateZoneDns(context.Background(), accountID, zoneName)
+
+	assert.NoError(t, err)
+	zone := zoneResponse.Data
+	wantSingle := &Zone{
+		ID: 1,
+		AccountID: 1010,
+		Name: "example.com",
+		Reverse: false,
+		CreatedAt: "2015-04-23T07:40:03Z",
+		UpdatedAt: "2015-04-23T07:40:03Z",
+	}
+	assert.Equal(t, wantSingle, zone)
+}
+
+func TestZonesService_DeactivateZoneDns(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/zones/example.com/activation", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/api/deactivateZoneService/success.http")
+
+		testMethod(t, r, "DELETE")
+		testHeaders(t, r)
+
+		w.WriteHeader(httpResponse.StatusCode)
+		_, _ = io.Copy(w, httpResponse.Body)
+	})
+
+	accountID := "1010"
+	zoneName := "example.com"
+
+	zoneResponse, err := client.Zones.ActivateZoneDns(context.Background(), accountID, zoneName)
+
+	assert.NoError(t, err)
+	zone := zoneResponse.Data
+	wantSingle := &Zone{
+		ID: 1,
+		AccountID: 1010,
+		Name: "example.com",
+		Reverse: false,
+		CreatedAt: "2015-04-23T07:40:03Z",
+		UpdatedAt: "2015-04-23T07:40:03Z",
+	}
+	assert.Equal(t, wantSingle, zone)
+}

--- a/dnsimple/zones_test.go
+++ b/dnsimple/zones_test.go
@@ -164,7 +164,7 @@ func TestZonesService_DeactivateZoneDns(t *testing.T) {
 	accountID := "1010"
 	zoneName := "example.com"
 
-	zoneResponse, err := client.Zones.ActivateZoneDns(context.Background(), accountID, zoneName)
+	zoneResponse, err := client.Zones.DeactivateZoneDns(context.Background(), accountID, zoneName)
 
 	assert.NoError(t, err)
 	zone := zoneResponse.Data

--- a/dnsimple/zones_test.go
+++ b/dnsimple/zones_test.go
@@ -137,10 +137,10 @@ func TestZonesService_ActivateZoneDns(t *testing.T) {
 	assert.NoError(t, err)
 	zone := zoneResponse.Data
 	wantSingle := &Zone{
-		ID: 1,
+		ID:        1,
 		AccountID: 1010,
-		Name: "example.com",
-		Reverse: false,
+		Name:      "example.com",
+		Reverse:   false,
 		CreatedAt: "2015-04-23T07:40:03Z",
 		UpdatedAt: "2015-04-23T07:40:03Z",
 	}
@@ -169,10 +169,10 @@ func TestZonesService_DeactivateZoneDns(t *testing.T) {
 	assert.NoError(t, err)
 	zone := zoneResponse.Data
 	wantSingle := &Zone{
-		ID: 1,
+		ID:        1,
 		AccountID: 1010,
-		Name: "example.com",
-		Reverse: false,
+		Name:      "example.com",
+		Reverse:   false,
 		CreatedAt: "2015-04-23T07:40:03Z",
 		UpdatedAt: "2015-04-23T07:40:03Z",
 	}

--- a/fixtures.http/api/activateZoneService/success.http
+++ b/fixtures.http/api/activateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1691471963
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"fe6afd982459be33146933235343d51d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8e8ac535-9f46-4304-8440-8c68c30427c3
+X-Runtime: 0.176579
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/fixtures.http/api/deactivateZoneService/success.http
+++ b/fixtures.http/api/deactivateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:52 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1691471962
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"5f30a37d01b99bb9e620ef1bbce9a014"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d2f7bba4-4c81-4818-81d2-c9bbe95f104e
+X-Runtime: 0.133278
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}


### PR DESCRIPTION
This PR implements https://github.com/dnsimple/dnsimple-developer/pull/502 which allows for the management of DNS resolution for a particular zone.

This PR also updates the `EmailForward` with new attributes replacing `To` and `From` for email forward resource creation. See the changelog for more information.

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/3
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/2