### PR TITLE
Add DomainRegistrantChange event types

### DIFF
--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -174,6 +174,20 @@ func (d *DomainEventData) unmarshalEventData(payload []byte) error {
 }
 
 //
+// DomainRegistrantChangeEvent
+//
+
+// DomainRegistrantChangegEventData represents the data node for a DomainRegistrantChange event.
+type DomainRegistrantChangeEventData struct {
+	Domain     *dnsimple.Domain     `json:"domain"`
+	Registrant *dnsimple.Contact    `json:"registrant"`
+}
+
+func (d *DomainRegistrantChangeEventData) unmarshalEventData(payload []byte) error {
+	return unmarshalEventData(payload, d)
+}
+
+//
 // EmailForwardEvent
 //
 

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -42,6 +42,8 @@ func switchEventData(event *Event) (EventDataContainer, error) {
 		"domain.renew",
 		"domain.delegation_change",
 		"domain.registrant_change",
+		"domain.registrant_change:started",
+		"domain.registrant_change:cancelled",
 		"domain.resolution_disable",
 		"domain.resolution_enable",
 		"domain.transfer": // TODO
@@ -170,6 +172,20 @@ type DomainEventData struct {
 }
 
 func (d *DomainEventData) unmarshalEventData(payload []byte) error {
+	return unmarshalEventData(payload, d)
+}
+
+//
+// DomainRegistrantChangeEvent
+//
+
+// DomainRegistrantChangegEventData represents the data node for a DomainRegistrantChange event.
+type DomainRegistrantChangeEventData struct {
+	Domain     *dnsimple.Domain     `json:"domain"`
+	Registrant *dnsimple.Contact    `json:"registrant"`
+}
+
+func (d *DomainRegistrantChangeEventData) unmarshalEventData(payload []byte) error {
 	return unmarshalEventData(payload, d)
 }
 

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -174,20 +174,6 @@ func (d *DomainEventData) unmarshalEventData(payload []byte) error {
 }
 
 //
-// DomainRegistrantChangeEvent
-//
-
-// DomainRegistrantChangegEventData represents the data node for a DomainRegistrantChange event.
-type DomainRegistrantChangeEventData struct {
-	Domain     *dnsimple.Domain     `json:"domain"`
-	Registrant *dnsimple.Contact    `json:"registrant"`
-}
-
-func (d *DomainRegistrantChangeEventData) unmarshalEventData(payload []byte) error {
-	return unmarshalEventData(payload, d)
-}
-
-//
 // EmailForwardEvent
 //
 

--- a/dnsimple/webhook/events_test.go
+++ b/dnsimple/webhook/events_test.go
@@ -458,6 +458,36 @@ func TestParseDomainEvent_Domain_RegistrantChange(t *testing.T) {
 	assert.Equal(t, "new_contact", data.Registrant.Label)
 }
 
+func TestParseDomainEvent_Domain_RegistrantChangeStarted(t *testing.T) {
+	payload := getHTTPRequestBodyFromFixture(t, "/webhooks/domain.registrant_change/status-started.http")
+
+	event, err := ParseEvent(payload)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "domain.registrant_change:started", event.Name)
+	assert.Regexp(t, regexpUUID, event.RequestID)
+
+	data, ok := event.GetData().(*DomainEventData)
+	assert.True(t, ok)
+	assert.Equal(t, "example-alpha.com", data.Domain.Name)
+	assert.Equal(t, "new_contact", data.Registrant.Label)
+}
+
+func TestParseDomainEvent_Domain_RegistrantChangeCancelled(t *testing.T) {
+	payload := getHTTPRequestBodyFromFixture(t, "/webhooks/domain.registrant_change/status-cancelled.http")
+
+	event, err := ParseEvent(payload)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "domain.registrant_change:cancelled", event.Name)
+	assert.Regexp(t, regexpUUID, event.RequestID)
+
+	data, ok := event.GetData().(*DomainEventData)
+	assert.True(t, ok)
+	assert.Equal(t, "example-alpha.com", data.Domain.Name)
+	assert.Equal(t, "new_contact", data.Registrant.Label)
+}
+
 func TestParseDomainEvent_Domain_ResolutionDisable(t *testing.T) {
 	payload := getHTTPRequestBodyFromFixture(t, "/webhooks/domain.resolution_disable/example.http")
 

--- a/fixtures.http/webhooks/domain.registrant_change/status-cancelled.http
+++ b/fixtures.http/webhooks/domain.registrant_change/status-cancelled.http
@@ -1,0 +1,9 @@
+POST / HTTP/1.1
+Host: example.com
+Accept-Encoding: gzip
+Content-Type: application/json
+User-Agent: DNSimple-Webhook-Notifier/8fd98a84516b72d5b863b27f93fcbaef61f06c03
+Content-Length: 1139
+Connection: keep-alive
+
+{"data": {"domain": {"id": 181984, "name": "example-alpha.com", "state": "registered", "account_id": 1385, "auto_renew": false, "created_at": "2020-06-04T19:15:14Z", "expires_at": "2021-06-05T02:15:00Z", "expires_on": "2021-06-05", "updated_at": "2020-06-04T21:04:17Z", "unicode_name": "example-alpha.com", "private_whois": false, "registrant_id": 2716}, "registrant": {"id": 2716, "fax": "", "city": "New York", "label": "new_contact", "phone": "+1 202-555-0191", "country": "US", "address1": "Test St", "address2": "", "job_title": "", "last_name": "Corp 2", "account_id": 1385, "created_at": "2020-06-04T21:03:47.226Z", "first_name": "DNSimple", "updated_at": "2020-06-04T21:03:47.226Z", "postal_code": "14801", "email_address": "support@dnsimple.com", "state_province": "NY", "organization_name": ""}}, "name": "domain.registrant_change:cancelled", "actor": {"id": "1331", "entity": "user", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1385, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "9ef5f6f7-fa00-4d31-a1dc-5f80ae783d93"}

--- a/fixtures.http/webhooks/domain.registrant_change/status-started.http
+++ b/fixtures.http/webhooks/domain.registrant_change/status-started.http
@@ -1,0 +1,9 @@
+POST / HTTP/1.1
+Host: example.com
+Accept-Encoding: gzip
+Content-Type: application/json
+User-Agent: DNSimple-Webhook-Notifier/8fd98a84516b72d5b863b27f93fcbaef61f06c03
+Content-Length: 1137
+Connection: keep-alive
+
+{"data": {"domain": {"id": 181984, "name": "example-alpha.com", "state": "registered", "account_id": 1385, "auto_renew": false, "created_at": "2020-06-04T19:15:14Z", "expires_at": "2021-06-05T02:15:00Z", "expires_on": "2021-06-05", "updated_at": "2020-06-04T21:04:17Z", "unicode_name": "example-alpha.com", "private_whois": false, "registrant_id": 2716}, "registrant": {"id": 2716, "fax": "", "city": "New York", "label": "new_contact", "phone": "+1 202-555-0191", "country": "US", "address1": "Test St", "address2": "", "job_title": "", "last_name": "Corp 2", "account_id": 1385, "created_at": "2020-06-04T21:03:47.226Z", "first_name": "DNSimple", "updated_at": "2020-06-04T21:03:47.226Z", "postal_code": "14801", "email_address": "support@dnsimple.com", "state_province": "NY", "organization_name": ""}}, "name": "domain.registrant_change:started", "actor": {"id": "1331", "entity": "user", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1385, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "9ef5f6f7-fa00-4d31-a1dc-5f80ae783d93"}


### PR DESCRIPTION
Add the struct type for the `domain.registrant_change` events.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1729