### PR TITLE
Add DomainTransferLockEnable and DomainTransferLockDisable event types

### DIFF
--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -191,19 +191,6 @@ func (d *DomainLockEventData) unmarshalEventData(payload []byte) error {
 }
 
 //
-// DomainUnlockEvent
-//
-
-// DomainUnlockEventData represents the data node for a DomainUnlock event.
-type DomainUnlockEventData struct {
-	Domain     *dnsimple.Domain     `json:"domain"`
-}
-
-func (d *DomainUnlockEventData) unmarshalEventData(payload []byte) error {
-	return unmarshalEventData(payload, d)
-}
-
-//
 // EmailForwardEvent
 //
 

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -174,6 +174,32 @@ func (d *DomainEventData) unmarshalEventData(payload []byte) error {
 }
 
 //
+// DomainLockEvent
+//
+
+// DomainLockEventData represents the data node for a DomainLock event.
+type DomainLockEventData struct {
+	Domain     *dnsimple.Domain     `json:"domain"`
+}
+
+func (d *DomainLockEventData) unmarshalEventData(payload []byte) error {
+	return unmarshalEventData(payload, d)
+}
+
+//
+// DomainUnlockEvent
+//
+
+// DomainUnlockEventData represents the data node for a DomainUnlock event.
+type DomainUnlockEventData struct {
+	Domain     *dnsimple.Domain     `json:"domain"`
+}
+
+func (d *DomainUnlockEventData) unmarshalEventData(payload []byte) error {
+	return unmarshalEventData(payload, d)
+}
+
+//
 // EmailForwardEvent
 //
 

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -46,10 +46,10 @@ func switchEventData(event *Event) (EventDataContainer, error) {
 		"domain.resolution_enable",
 		"domain.transfer": // TODO
 		data = &DomainEventData{}
-	case // domain lock
-		"domain.lock",
-		"domain.unlock":
-		data =  &DomainLockEventData{}
+	case // domain transfer lock
+		"domain.transfer_lock_enable",
+		"domain.transfer_lock_disable":
+		data =  &DomainTransferLockEventData{}
 	case // email forward
 		"email_forward.create",
 		"email_forward.delete",
@@ -181,12 +181,12 @@ func (d *DomainEventData) unmarshalEventData(payload []byte) error {
 // DomainLockEvent
 //
 
-// DomainLockEventData represents the data node for a DomainLock or DomainUnlock event.
-type DomainLockEventData struct {
+// DomainTransferLockEventData represents the data node for a DomainTransferLockEnable or DomainTransferLockDisable event.
+type DomainTransferLockEventData struct {
 	Domain     *dnsimple.Domain     `json:"domain"`
 }
 
-func (d *DomainLockEventData) unmarshalEventData(payload []byte) error {
+func (d *DomainTransferLockEventData) unmarshalEventData(payload []byte) error {
 	return unmarshalEventData(payload, d)
 }
 

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -37,13 +37,15 @@ func switchEventData(event *Event) (EventDataContainer, error) {
 		"domain.auto_renewal_disable",
 		"domain.auto_renewal_enable",
 		"domain.create",
-		"domain.delete",
-		"domain.register",
-		"domain.renew",
 		"domain.delegation_change",
+		"domain.delete",
+		"domain.lock",
+		"domain.register",
 		"domain.registrant_change",
+		"domain.renew",
 		"domain.resolution_disable",
 		"domain.resolution_enable",
+		"domain.unlock",
 		"domain.transfer": // TODO
 		data = &DomainEventData{}
 	case // email forward
@@ -161,7 +163,7 @@ func (d *DNSSECEventData) unmarshalEventData(payload []byte) error {
 // DomainEvent
 //
 
-// DomainEventData represents the data node for a Contact event.
+// DomainEventData represents the data node for a Domain event.
 type DomainEventData struct {
 	Auto       bool                 `json:"auto"`
 	Domain     *dnsimple.Domain     `json:"domain"`
@@ -170,32 +172,6 @@ type DomainEventData struct {
 }
 
 func (d *DomainEventData) unmarshalEventData(payload []byte) error {
-	return unmarshalEventData(payload, d)
-}
-
-//
-// DomainLockEvent
-//
-
-// DomainLockEventData represents the data node for a DomainLock event.
-type DomainLockEventData struct {
-	Domain     *dnsimple.Domain     `json:"domain"`
-}
-
-func (d *DomainLockEventData) unmarshalEventData(payload []byte) error {
-	return unmarshalEventData(payload, d)
-}
-
-//
-// DomainUnlockEvent
-//
-
-// DomainUnlockEventData represents the data node for a DomainUnlock event.
-type DomainUnlockEventData struct {
-	Domain     *dnsimple.Domain     `json:"domain"`
-}
-
-func (d *DomainUnlockEventData) unmarshalEventData(payload []byte) error {
 	return unmarshalEventData(payload, d)
 }
 

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -39,15 +39,17 @@ func switchEventData(event *Event) (EventDataContainer, error) {
 		"domain.create",
 		"domain.delegation_change",
 		"domain.delete",
-		"domain.lock",
 		"domain.register",
 		"domain.registrant_change",
 		"domain.renew",
 		"domain.resolution_disable",
 		"domain.resolution_enable",
-		"domain.transfer", // TODO
-		"domain.unlock":
+		"domain.transfer": // TODO
 		data = &DomainEventData{}
+	case // domain lock
+		"domain.lock",
+		"domain.unlock":
+		data =  &DomainLockEventData{}
 	case // email forward
 		"email_forward.create",
 		"email_forward.delete",
@@ -172,6 +174,32 @@ type DomainEventData struct {
 }
 
 func (d *DomainEventData) unmarshalEventData(payload []byte) error {
+	return unmarshalEventData(payload, d)
+}
+
+//
+// DomainLockEvent
+//
+
+// DomainLockEventData represents the data node for a DomainLock event.
+type DomainLockEventData struct {
+	Domain     *dnsimple.Domain     `json:"domain"`
+}
+
+func (d *DomainLockEventData) unmarshalEventData(payload []byte) error {
+	return unmarshalEventData(payload, d)
+}
+
+//
+// DomainUnlockEvent
+//
+
+// DomainUnlockEventData represents the data node for a DomainUnlock event.
+type DomainUnlockEventData struct {
+	Domain     *dnsimple.Domain     `json:"domain"`
+}
+
+func (d *DomainUnlockEventData) unmarshalEventData(payload []byte) error {
 	return unmarshalEventData(payload, d)
 }
 

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -45,8 +45,8 @@ func switchEventData(event *Event) (EventDataContainer, error) {
 		"domain.renew",
 		"domain.resolution_disable",
 		"domain.resolution_enable",
-		"domain.unlock",
-		"domain.transfer": // TODO
+		"domain.transfer", // TODO
+		"domain.unlock":
 		data = &DomainEventData{}
 	case // email forward
 		"email_forward.create",

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -181,7 +181,7 @@ func (d *DomainEventData) unmarshalEventData(payload []byte) error {
 // DomainLockEvent
 //
 
-// DomainLockEventData represents the data node for a DomainLock event.
+// DomainLockEventData represents the data node for a DomainLock or DomainUnlock event.
 type DomainLockEventData struct {
 	Domain     *dnsimple.Domain     `json:"domain"`
 }

--- a/dnsimple/webhook/events.go
+++ b/dnsimple/webhook/events.go
@@ -178,7 +178,7 @@ func (d *DomainEventData) unmarshalEventData(payload []byte) error {
 }
 
 //
-// DomainLockEvent
+// DomainTransferLockEvent
 //
 
 // DomainTransferLockEventData represents the data node for a DomainTransferLockEnable or DomainTransferLockDisable event.

--- a/dnsimple/webhook/events_test.go
+++ b/dnsimple/webhook/events_test.go
@@ -500,6 +500,34 @@ func TestParseDomainEvent_Domain_Transfer(t *testing.T) {
 	assert.Equal(t, "example.com", data.Domain.Name)
 }
 
+func TestParseDomainEvent_Domain_TransferLockEnable(t *testing.T) {
+	payload := `{"data": {"domain": {"id": 1, "name": "example.com", "state": "registered", "account_id": 1010, "auto_renew": false, "created_at": "2023-03-02T02:39:18Z", "expires_at": "2024-03-02T02:39:22Z", "expires_on": "2024-03-02", "updated_at": "2023-08-31T06:46:48Z", "unicode_name": "example.com", "private_whois": false, "registrant_id": 101}}, "name": "domain.transfer_lock_enable", "actor": {"id": "1010", "entity": "account", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1010, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "0f31483c-c303-497b-8a88-2edb48aa111e"}`
+
+	event, err := ParseEvent([]byte(payload))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "domain.transfer_lock_enable", event.Name)
+	assert.Regexp(t, regexpUUID, event.RequestID)
+
+	data, ok := event.GetData().(*DomainTransferLockEventData)
+	assert.True(t, ok)
+	assert.Equal(t, "example.com", data.Domain.Name)
+}
+
+func TestParseDomainEvent_Domain_TransferLockDisable(t *testing.T) {
+	payload := `{"data": {"domain": {"id": 1, "name": "example.com", "state": "registered", "account_id": 1010, "auto_renew": false, "created_at": "2023-03-02T02:39:18Z", "expires_at": "2024-03-02T02:39:22Z", "expires_on": "2024-03-02", "updated_at": "2023-08-31T06:46:48Z", "unicode_name": "example.com", "private_whois": false, "registrant_id": 101}}, "name": "domain.transfer_lock_disable", "actor": {"id": "1010", "entity": "account", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1010, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "0f31483c-c303-497b-8a88-2edb48aa111e"}`
+
+	event, err := ParseEvent([]byte(payload))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "domain.transfer_lock_disable", event.Name)
+	assert.Regexp(t, regexpUUID, event.RequestID)
+
+	data, ok := event.GetData().(*DomainTransferLockEventData)
+	assert.True(t, ok)
+	assert.Equal(t, "example.com", data.Domain.Name)
+}
+
 func TestParseEmailForwardEvent_EmailForward_Create(t *testing.T) {
 	payload := getHTTPRequestBodyFromFixture(t, "/webhooks/email_forward.create/example.http")
 

--- a/dnsimple/webhook/events_test.go
+++ b/dnsimple/webhook/events_test.go
@@ -501,9 +501,9 @@ func TestParseDomainEvent_Domain_Transfer(t *testing.T) {
 }
 
 func TestParseDomainEvent_Domain_TransferLockEnable(t *testing.T) {
-	payload := `{"data": {"domain": {"id": 1, "name": "example.com", "state": "registered", "account_id": 1010, "auto_renew": false, "created_at": "2023-03-02T02:39:18Z", "expires_at": "2024-03-02T02:39:22Z", "expires_on": "2024-03-02", "updated_at": "2023-08-31T06:46:48Z", "unicode_name": "example.com", "private_whois": false, "registrant_id": 101}}, "name": "domain.transfer_lock_enable", "actor": {"id": "1010", "entity": "account", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1010, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "0f31483c-c303-497b-8a88-2edb48aa111e"}`
+	payload := getHTTPRequestBodyFromFixture(t, "/webhooks/domain.transfer_lock_enable/example.http")
 
-	event, err := ParseEvent([]byte(payload))
+	event, err := ParseEvent(payload)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "domain.transfer_lock_enable", event.Name)
@@ -515,7 +515,7 @@ func TestParseDomainEvent_Domain_TransferLockEnable(t *testing.T) {
 }
 
 func TestParseDomainEvent_Domain_TransferLockDisable(t *testing.T) {
-	payload := `{"data": {"domain": {"id": 1, "name": "example.com", "state": "registered", "account_id": 1010, "auto_renew": false, "created_at": "2023-03-02T02:39:18Z", "expires_at": "2024-03-02T02:39:22Z", "expires_on": "2024-03-02", "updated_at": "2023-08-31T06:46:48Z", "unicode_name": "example.com", "private_whois": false, "registrant_id": 101}}, "name": "domain.transfer_lock_disable", "actor": {"id": "1010", "entity": "account", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1010, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "0f31483c-c303-497b-8a88-2edb48aa111e"}`
+	payload := getHTTPRequestBodyFromFixture(t, "/webhooks/domain.transfer_lock_disable/example.http")
 
 	event, err := ParseEvent([]byte(payload))
 

--- a/fixtures.http/webhooks/domain.transfer_lock_disable/example.http
+++ b/fixtures.http/webhooks/domain.transfer_lock_disable/example.http
@@ -1,0 +1,9 @@
+POST / HTTP/1.1
+Host: example.com
+Accept-Encoding: gzip
+Content-Type: application/json
+User-Agent: DNSimple-Webhook-Notifier/8fd98a84516b72d5b863b27f93fcbaef61f06c03
+Content-Length: 667
+Connection: keep-alive
+
+{"data": {"domain": {"id": 1, "name": "example.com", "state": "registered", "account_id": 1010, "auto_renew": false, "created_at": "2023-03-02T02:39:18Z", "expires_at": "2024-03-02T02:39:22Z", "expires_on": "2024-03-02", "updated_at": "2023-08-31T06:46:48Z", "unicode_name": "example.com", "private_whois": false, "registrant_id": 101}}, "name": "domain.transfer_lock_disable", "actor": {"id": "1010", "entity": "account", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1010, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "0f31483c-c303-497b-8a88-2edb48aa111e"}

--- a/fixtures.http/webhooks/domain.transfer_lock_enable/example.http
+++ b/fixtures.http/webhooks/domain.transfer_lock_enable/example.http
@@ -1,0 +1,9 @@
+POST / HTTP/1.1
+Host: example.com
+Accept-Encoding: gzip
+Content-Type: application/json
+User-Agent: DNSimple-Webhook-Notifier/8fd98a84516b72d5b863b27f93fcbaef61f06c03
+Content-Length: 666
+Connection: keep-alive
+
+{"data": {"domain": {"id": 1, "name": "example.com", "state": "registered", "account_id": 1010, "auto_renew": false, "created_at": "2023-03-02T02:39:18Z", "expires_at": "2024-03-02T02:39:22Z", "expires_on": "2024-03-02", "updated_at": "2023-08-31T06:46:48Z", "unicode_name": "example.com", "private_whois": false, "registrant_id": 101}}, "name": "domain.transfer_lock_enable", "actor": {"id": "1010", "entity": "account", "pretty": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "account": {"id": 1010, "display": "xxxxxxx-xxxxxxx-xxxxxxx", "identifier": "xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com"}, "api_version": "v2", "request_identifier": "0f31483c-c303-497b-8a88-2edb48aa111e"}


### PR DESCRIPTION
Add the struct types for the `domain.transfer_lock_enable` and `domain.transfer_lock_disable` events.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1728
