### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+ENHANCEMENTS:
+
+- NEW: Added `Secondary`, `LastTransferredAt`, `Active` to `Zone` (dnsimple/dnsimple-go)
+
 ## 1.5.0
 
 FEATURES:

--- a/dnsimple/zones.go
+++ b/dnsimple/zones.go
@@ -15,12 +15,15 @@ type ZonesService struct {
 
 // Zone represents a Zone in DNSimple.
 type Zone struct {
-	ID        int64  `json:"id,omitempty"`
-	AccountID int64  `json:"account_id,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Reverse   bool   `json:"reverse,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	ID                int64  `json:"id,omitempty"`
+	AccountID         int64  `json:"account_id,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Reverse           bool   `json:"reverse,omitempty"`
+	Secondary         bool   `json:"secondary,omitempty"`
+	LastTransferredAt string `json:"last_transferred_at,omitempty"`
+	Active            bool   `json:"active,omitempty"`
+	CreatedAt         string `json:"created_at,omitempty"`
+	UpdatedAt         string `json:"updated_at,omitempty"`
 }
 
 // ZoneFile represents a Zone File in DNSimple.

--- a/dnsimple/zones_test.go
+++ b/dnsimple/zones_test.go
@@ -79,12 +79,15 @@ func TestZonesService_GetZone(t *testing.T) {
 	assert.NoError(t, err)
 	zone := zoneResponse.Data
 	wantSingle := &Zone{
-		ID:        1,
-		AccountID: 1010,
-		Name:      "example-alpha.com",
-		Reverse:   false,
-		CreatedAt: "2015-04-23T07:40:03Z",
-		UpdatedAt: "2015-04-23T07:40:03Z"}
+		ID:                1,
+		AccountID:         1010,
+		Name:              "example-alpha.com",
+		Reverse:           false,
+		Secondary:         false,
+		LastTransferredAt: "",
+		Active:            true,
+		CreatedAt:         "2015-04-23T07:40:03Z",
+		UpdatedAt:         "2015-04-23T07:40:03Z"}
 	assert.Equal(t, wantSingle, zone)
 }
 
@@ -137,12 +140,15 @@ func TestZonesService_ActivateZoneDns(t *testing.T) {
 	assert.NoError(t, err)
 	zone := zoneResponse.Data
 	wantSingle := &Zone{
-		ID:        1,
-		AccountID: 1010,
-		Name:      "example.com",
-		Reverse:   false,
-		CreatedAt: "2015-04-23T07:40:03Z",
-		UpdatedAt: "2015-04-23T07:40:03Z",
+		ID:                1,
+		AccountID:         1010,
+		Name:              "example.com",
+		Reverse:           false,
+		Secondary:         false,
+		LastTransferredAt: "",
+		Active:            true,
+		CreatedAt:         "2015-04-23T07:40:03Z",
+		UpdatedAt:         "2015-04-23T07:40:03Z",
 	}
 	assert.Equal(t, wantSingle, zone)
 }
@@ -169,12 +175,15 @@ func TestZonesService_DeactivateZoneDns(t *testing.T) {
 	assert.NoError(t, err)
 	zone := zoneResponse.Data
 	wantSingle := &Zone{
-		ID:        1,
-		AccountID: 1010,
-		Name:      "example.com",
-		Reverse:   false,
-		CreatedAt: "2015-04-23T07:40:03Z",
-		UpdatedAt: "2015-04-23T07:40:03Z",
+		ID:                1,
+		AccountID:         1010,
+		Name:              "example.com",
+		Reverse:           false,
+		Secondary:         false,
+		LastTransferredAt: "",
+		Active:            false,
+		CreatedAt:         "2015-04-23T07:40:03Z",
+		UpdatedAt:         "2015-04-23T07:40:03Z",
 	}
 	assert.Equal(t, wantSingle, zone)
 }

--- a/fixtures.http/api/getZone/success.http
+++ b/fixtures.http/api/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/fixtures.http/api/listZones/success.http
+++ b/fixtures.http/api/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `Secondary`, `LastTransferredAt`, `Active` to `Zone` struct

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17