### PR TITLE
Restore methods

### DIFF
--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -323,6 +323,21 @@ type DomainRenewalResponse struct {
 	Data *DomainRenewal `json:"data"`
 }
 
+// DomainRestore represents the result of a domain restore call.
+type DomainRestore struct {
+	ID        int64  `json:"id"`
+	DomainID  int64  `json:"domain_id"`
+	State     string `json:"state"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// DomainRestoreResponse represents a response from an API method that returns a domain restore.
+type DomainRestoreResponse struct {
+	Response
+	Data *DomainRestore `json:"data"`
+}
+
 // GetDomainRenewal gets the details of an existing domain renewal.
 //
 // See https://developer.dnsimple.com/v2/registrar/#getDomainRenewal
@@ -354,6 +369,22 @@ type RenewDomainInput struct {
 // See https://developer.dnsimple.com/v2/registrar/#renewDomain
 func (s *RegistrarService) RenewDomain(ctx context.Context, accountID string, domainName string, input *RenewDomainInput) (*DomainRenewalResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/renewals", accountID, domainName))
+	renewalResponse := &DomainRenewalResponse{}
+
+	resp, err := s.client.post(ctx, path, input, renewalResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	renewalResponse.HTTPResponse = resp
+	return renewalResponse, nil
+}
+
+// RestoreDomain restores a domain name.
+//
+// See https://developer.dnsimple.com/v2/registrar/#renewDomain
+func (s *RegistrarService) RestoreDomain(ctx context.Context, accountID string, domainName string, input *RenewDomainInput) (*DomainRenewalResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/restores", accountID, domainName))
 	renewalResponse := &DomainRenewalResponse{}
 
 	resp, err := s.client.post(ctx, path, input, renewalResponse)

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -395,3 +395,20 @@ func (s *RegistrarService) RestoreDomain(ctx context.Context, accountID string, 
 	renewalResponse.HTTPResponse = resp
 	return renewalResponse, nil
 }
+
+// GetDomainRestore gets the details of an existing domain restore.
+//
+// See https://developer.dnsimple.com/v2/registrar/#getDomainRestore
+func (s *RegistrarService) GetDomainRestore(ctx context.Context, accountID string, domainName string, domainRestoreID string) (*DomainRestoreResponse, error) {
+	var err error
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/restores/%v", accountID, domainName, domainRestoreID))
+	res := &DomainRestoreResponse{}
+
+	resp, err := s.client.get(ctx, path, res)
+	if err != nil {
+		return nil, err
+	}
+
+	res.HTTPResponse = resp
+	return res, nil
+}

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -363,3 +363,28 @@ func TestRegistrarService_RenewDomain(t *testing.T) {
 	assert.Equal(t, int64(1), renewal.ID)
 	assert.Equal(t, int64(999), renewal.DomainID)
 }
+
+func TestRegistrarService_RestoreDomain(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/registrar/domains/example.com/restores", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/api/restoreDomain/success.http")
+
+		testMethod(t, r, "POST")
+		testHeaders(t, r)
+
+		//want := map[string]interface{}{}
+		//testRequestJSON(t, r, want)
+
+		w.WriteHeader(httpResponse.StatusCode)
+		_, _ = io.Copy(w, httpResponse.Body)
+	})
+
+	restoreResponse, err := client.Registrar.RestoreDomain(context.Background(), "1010", "example.com", nil)
+
+	assert.NoError(t, err)
+	restore := restoreResponse.Data
+	assert.Equal(t, int64(43), restore.ID)
+	assert.Equal(t, int64(214), restore.DomainID)
+}

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -388,3 +388,28 @@ func TestRegistrarService_RestoreDomain(t *testing.T) {
 	assert.Equal(t, int64(43), restore.ID)
 	assert.Equal(t, int64(214), restore.DomainID)
 }
+
+func TestRegistrarService_GetDomainRestore(t *testing.T) {
+	setupMockServer()
+	defer teardownMockServer()
+
+	mux.HandleFunc("/v2/1010/registrar/domains/bingo.pizza/restores/1", func(w http.ResponseWriter, r *http.Request) {
+		httpResponse := httpResponseFixture(t, "/api/getDomainRestore/success.http")
+
+		testMethod(t, r, "GET")
+		testHeaders(t, r)
+
+		w.WriteHeader(httpResponse.StatusCode)
+		_, _ = io.Copy(w, httpResponse.Body)
+	})
+
+	checkResponse, err := client.Registrar.GetDomainRestore(context.Background(), "1010", "bingo.pizza", "1")
+
+	assert.NoError(t, err)
+	check := checkResponse.Data
+	assert.Equal(t, check.ID, int64(1))
+	assert.Equal(t, check.DomainID, int64(999))
+	assert.Equal(t, check.State, "restored")
+	assert.Equal(t, check.CreatedAt, "2016-12-09T19:46:45Z")
+	assert.Equal(t, check.UpdatedAt, "2016-12-12T19:46:45Z")
+}

--- a/fixtures.http/api/getDomainRestore/success.http
+++ b/fixtures.http/api/getDomainRestore/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Fri, 09 Dec 2016 19:46:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":999,"state":"restored","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-12T19:46:45Z"}}

--- a/fixtures.http/api/restoreDomain/success.http
+++ b/fixtures.http/api/restoreDomain/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Fri, 09 Dec 2016 19:46:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":43,"domain_id":214,"state":"new","created_at":"2024-02-14T14:40:42Z","updated_at":"2024-02-14T14:40:42Z"}}


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-business/issues/1654.

## Description
This adds two methods to the library: (1) `RestoreDomain` and (2) `GetDomainRestore`. The API endpoint implementation is in https://github.com/dnsimple/dnsimple-app/pull/25863.