### PR TITLE
Update `EmailForward` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- CHANGED: Deprecated `AliasName` in `EmailForward
+
 ## 2.0.0
 
 - CHANGED: Bump dependencies

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -9,11 +9,10 @@ import (
 type EmailForward struct {
 	ID       int64 `json:"id,omitempty"`
 	DomainID int64 `json:"domain_id,omitempty"`
-	// Deprecated: for requests, please use `AliasName` instead; for responses, please use `AliasEmail` instead.
+	// Deprecated: use `AliasEmail` instead.
 	From string `json:"from,omitempty"`
-	// WARNING: This is not set in responses, please use `AliasEmail` instead.
-	AliasName string `json:"alias_name,omitempty"`
-	// WARNING: This is not used by requests, please use `AliasName` instead.
+	// Deprecated: use `AliasEmail` instead.
+	AliasName  string `json:"alias_name,omitempty"`
 	AliasEmail string `json:"alias_email,omitempty"`
 	// Deprecated: please use `DestinationEmail` instead.
 	To               string `json:"to,omitempty"`


### PR DESCRIPTION
See https://github.com/dnsimple/dnsimple-developer/issues/315 for reference

The Go API client already defines the new fields and deprecates the old ones. However, it defines a bogus `AliasName` that must not be used.

In this PR:
- Deprecate `AliasName` in `EmailForward` 