### PR TITLE
Add `active` attribute in `EmailForward`

### DIFF
--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -18,6 +18,7 @@ type EmailForward struct {
 	// Deprecated: please use `DestinationEmail` instead.
 	To               string `json:"to,omitempty"`
 	DestinationEmail string `json:"destination_email,omitempty"`
+	Active           bool   `json:"active,omitempty"`
 	CreatedAt        string `json:"created_at,omitempty"`
 	UpdatedAt        string `json:"updated_at,omitempty"`
 }

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -112,6 +112,7 @@ func TestDomainsService_GetEmailForward(t *testing.T) {
 		AliasEmail:       "example@dnsimple.xyz",
 		To:               "example@example.com",
 		DestinationEmail: "example@example.com",
+		Active:           true,
 		CreatedAt:        "2021-01-25T13:54:40Z",
 		UpdatedAt:        "2021-01-25T13:54:40Z"}
 	assert.Equal(t, wantSingle, forward)

--- a/fixtures.http/api/getEmailForward/success.http
+++ b/fixtures.http/api/getEmailForward/success.http
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}
+{"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","active":true,"created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}


### PR DESCRIPTION
Fixes https://github.com/dnsimple/dnsimple-go/issues/179

This PR adds the new `active` attribute in `EmailForward` to expose its value from DNSimple API's responses.