### PR TITLE
Patch cycle - 2024 / Cycle 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         go-version:
           - "1.21"
           - "1.22"
+          - "1.23"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-- NEW: Added alias_email and destination_email to EmailForward
+- NEW: Added `active` attribute to EmailForward
 - CHANGED: Added support for Go >= 1.23
 - CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 - CHANGED: Bump dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- CHANGED: Added support for Go >= 1.23
+
 ## 2.0.0
 
 - CHANGED: Bump dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 - CHANGED: Added support for Go >= 1.23
+- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 - CHANGED: Bump dependencies
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 - CHANGED: Added support for Go >= 1.23
+- CHANGED: Bump dependencies
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+- NEW: Added alias_email and destination_email to EmailForward
 - CHANGED: Added support for Go >= 1.23
 - CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 - CHANGED: Bump dependencies

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2022 DNSimple Corporation
+Copyright (c) 2014-2024 DNSimple Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -132,4 +132,4 @@ For instructions about contributing and testing, visit the [CONTRIBUTING](CONTRI
 
 ## License
 
-Copyright (c) 2014-2022 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2014-2024 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/dnsimple/domains_collaborators.go
+++ b/dnsimple/domains_collaborators.go
@@ -45,6 +45,8 @@ type CollaboratorsResponse struct {
 
 // ListCollaborators list the collaborators for a domain.
 //
+// Deprecated: Domain collaborators have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
+//
 // See https://developer.dnsimple.com/v2/domains/collaborators#list
 func (s *DomainsService) ListCollaborators(ctx context.Context, accountID, domainIdentifier string, options *ListOptions) (*CollaboratorsResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
@@ -66,6 +68,8 @@ func (s *DomainsService) ListCollaborators(ctx context.Context, accountID, domai
 
 // AddCollaborator adds a new collaborator to the domain in the account.
 //
+// Deprecated: Domain collaborators have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
+//
 // See https://developer.dnsimple.com/v2/domains/collaborators#add
 func (s *DomainsService) AddCollaborator(ctx context.Context, accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*CollaboratorResponse, error) {
 	path := versioned(collaboratorPath(accountID, domainIdentifier, 0))
@@ -81,6 +85,8 @@ func (s *DomainsService) AddCollaborator(ctx context.Context, accountID string, 
 }
 
 // RemoveCollaborator PERMANENTLY deletes a domain from the account.
+//
+// Deprecated: Domain collaborators have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 //
 // See https://developer.dnsimple.com/v2/domains/collaborators#remove
 func (s *DomainsService) RemoveCollaborator(ctx context.Context, accountID string, domainIdentifier string, collaboratorID int64) (*CollaboratorResponse, error) {


### PR DESCRIPTION
The changes to go out in the next version (3.0.0) are:

- NEW: Added `active` attribute to EmailForward
- CHANGED: Added support for Go >= 1.23
- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
- CHANGED: Bump dependencies

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/231