### PR TITLE
Pass in options when making ListRegistrantChange API call

### DIFF
--- a/dnsimple/registrar_registrant_changes.go
+++ b/dnsimple/registrar_registrant_changes.go
@@ -83,9 +83,14 @@ type RegistrantChangeDeleteResponse struct {
 // ListRegistrantChange lists registrant changes in the account.
 //
 // See https://developer.dnsimple.com/v2/registrar/#listRegistrantChanges
-func (s *RegistrarService) ListRegistrantChange(ctx context.Context, accountID string, _ *RegistrantChangeListOptions) (*RegistrantChangesListResponse, error) {
+func (s *RegistrarService) ListRegistrantChange(ctx context.Context, accountID string, options *RegistrantChangeListOptions) (*RegistrantChangesListResponse, error) {
 	path := versioned(fmt.Sprintf("/%v/registrar/registrant_changes", accountID))
 	changeResponse := &RegistrantChangesListResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := s.client.get(ctx, path, changeResponse)
 	if err != nil {


### PR DESCRIPTION
Pass in options when making ListRegistrantChange API call, as disccused in https://github.com/dnsimple/dnsimple-go/pull/194#discussion_r2055463518

## QA

✅ Tested using the client to make this call in Sandbox

```
 "GET /v2/1640/registrar/registrant_changes?state=open HTTP/1.0" 200 91 0.0208
```