### PR TITLE
Remove from and to from EmailForwards

### DIFF
--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -12,7 +12,7 @@ type EmailForward struct {
 	// WARNING: This is not set in responses, please use `AliasEmail` instead.
 	AliasName string `json:"alias_name,omitempty"`
 	// WARNING: This is not used by requests, please use `AliasName` instead.
-	AliasEmail string `json:"alias_email,omitempty"`
+	AliasEmail       string `json:"alias_email,omitempty"`
 	DestinationEmail string `json:"destination_email,omitempty"`
 	Active           bool   `json:"active,omitempty"`
 	CreatedAt        string `json:"created_at,omitempty"`

--- a/dnsimple/domains_email_forwards.go
+++ b/dnsimple/domains_email_forwards.go
@@ -9,14 +9,10 @@ import (
 type EmailForward struct {
 	ID       int64 `json:"id,omitempty"`
 	DomainID int64 `json:"domain_id,omitempty"`
-	// Deprecated: for requests, please use `AliasName` instead; for responses, please use `AliasEmail` instead.
-	From string `json:"from,omitempty"`
 	// WARNING: This is not set in responses, please use `AliasEmail` instead.
 	AliasName string `json:"alias_name,omitempty"`
 	// WARNING: This is not used by requests, please use `AliasName` instead.
 	AliasEmail string `json:"alias_email,omitempty"`
-	// Deprecated: please use `DestinationEmail` instead.
-	To               string `json:"to,omitempty"`
 	DestinationEmail string `json:"destination_email,omitempty"`
 	Active           bool   `json:"active,omitempty"`
 	CreatedAt        string `json:"created_at,omitempty"`

--- a/dnsimple/domains_email_forwards_test.go
+++ b/dnsimple/domains_email_forwards_test.go
@@ -70,20 +70,20 @@ func TestDomainsService_CreateEmailForward(t *testing.T) {
 		testMethod(t, r, "POST")
 		testHeaders(t, r)
 
-		want := map[string]interface{}{"from": "me"}
+		want := map[string]interface{}{"alias_name": "me"}
 		testRequestJSON(t, r, want)
 
 		w.WriteHeader(httpResponse.StatusCode)
 		_, _ = io.Copy(w, httpResponse.Body)
 	})
 
-	forwardAttributes := EmailForward{From: "me"}
+	forwardAttributes := EmailForward{AliasName: "me"}
 
 	forwardResponse, err := client.Domains.CreateEmailForward(context.Background(), "1010", "example.com", forwardAttributes)
 	assert.NoError(t, err)
 	forward := forwardResponse.Data
 	assert.Equal(t, int64(41872), forward.ID)
-	assert.Regexp(t, regexpEmail, forward.From)
+	assert.Regexp(t, regexpEmail, forward.AliasEmail)
 }
 
 func TestDomainsService_GetEmailForward(t *testing.T) {
@@ -107,10 +107,8 @@ func TestDomainsService_GetEmailForward(t *testing.T) {
 	wantSingle := &EmailForward{
 		ID:               41872,
 		DomainID:         235146,
-		From:             "example@dnsimple.xyz",
 		AliasName:        "",
 		AliasEmail:       "example@dnsimple.xyz",
-		To:               "example@example.com",
 		DestinationEmail: "example@example.com",
 		Active:           true,
 		CreatedAt:        "2021-01-25T13:54:40Z",


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/17733.

## Description
This PR removes the deprecated `from` and `to` models from the `EmailForward` model.