### PR TITLE
Add support for custom debug logger (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is
 
 ## main
 
+### Added
+
+- Added `Logger *slog.Logger` to `Client` struct to support structured logging using the `log/slog` standard library package.
+
 ### Changed
 
 - Updated the `listCharges` test fixture to include a certificate purchase entry demonstrating that `ProductReference` is a string even when it represents a numeric ID. (#257)
+- Updated `NewClient` to initialize a default `slog` logger with a `component=dnsimple-go` attribute.
+- Internal logging now uses `slog.Debug` for request and response details.
+
+### Deprecated
+
+- Deprecated `Debug` field in `Client` struct. Use `Logger` and configure the desired `slog.Level` instead.
 
 ### Removed
 

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -37,6 +37,11 @@ const (
 	apiVersion = "v2"
 )
 
+// Logger interface allows consumers to provide a custom logger for debug output.
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
 // Client represents a client to the DNSimple API.
 type Client struct {
 	// httpClient is the underlying HTTP client
@@ -69,6 +74,10 @@ type Client struct {
 
 	// Set to true to output debugging logs during API calls
 	Debug bool
+
+	// Optional logger for debug output.
+	// If not set, the global log package is used.
+	DebugLogger Logger
 }
 
 // ListOptions contains the common options you can pass to a List method
@@ -118,6 +127,16 @@ func NewClient(httpClient *http.Client) *Client {
 //	customAgentFlag dnsimple-go/1.0
 func (c *Client) SetUserAgent(ua string) {
 	c.UserAgent = ua
+}
+
+func (c *Client) debugLogf(format string, v ...interface{}) {
+	if c.Debug {
+		if c.DebugLogger != nil {
+			c.DebugLogger.Printf(format, v...)
+		} else {
+			log.Printf(format, v...)
+		}
+	}
 }
 
 // formatUserAgent builds the final user agent to use for HTTP requests.
@@ -177,18 +196,14 @@ func (c *Client) makeRequest(ctx context.Context, method, path string, payload, 
 		return nil, err
 	}
 
-	if c.Debug {
-		log.Printf("Request (%v): %#v", req.URL, req)
-	}
+	c.debugLogf("Request (%v): %#v", req.URL, req)
 
 	resp, err := c.request(ctx, req, obj)
 	if err != nil {
 		return nil, err
 	}
 
-	if c.Debug {
-		log.Printf("Response: %#v", resp)
-	}
+	c.debugLogf("Response: %#v", resp)
 
 	return resp, nil
 }

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -214,16 +214,16 @@ func (c *Client) makeRequest(ctx context.Context, method, path string, payload, 
 }
 
 func (c *Client) resolveLogger() *slog.Logger {
-	if c.Logger != nil {
-		return c.Logger
-	}
-
-	if c.Debug {
-		// Backward compat: honour the old Debug flag by enabling debug level
+	// Check Debug first so the backward compat
+	// path is always reachable.
+	if c.Debug && c.Logger == nil {
 		handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 			Level: slog.LevelDebug,
 		})
 		return slog.New(handler).With("component", logComponent)
+	}
+	if c.Logger != nil {
+		return c.Logger
 	}
 
 	return slog.Default().With("component", logComponent)

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -9,8 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -35,12 +36,9 @@ const (
 	defaultUserAgent = "dnsimple-go/" + Version
 
 	apiVersion = "v2"
-)
 
-// Logger interface allows consumers to provide a custom logger for debug output.
-type Logger interface {
-	Printf(format string, v ...interface{})
-}
+	logComponent = "dnsimple-go"
+)
 
 // Client represents a client to the DNSimple API.
 type Client struct {
@@ -72,12 +70,14 @@ type Client struct {
 	Webhooks          *WebhooksService
 	Zones             *ZonesService
 
-	// Set to true to output debugging logs during API calls
-	Debug bool
+	// Logger is the logger used by the client.
+	// If not set, slog.Default() is used.
+	Logger *slog.Logger
 
-	// Optional logger for debug output.
-	// If not set, the global log package is used.
-	DebugLogger Logger
+	// Set to true to output debugging logs during API calls.
+	//
+	// Deprecated: Use Logger and slog levels instead.
+	Debug bool
 }
 
 // ListOptions contains the common options you can pass to a List method
@@ -100,7 +100,10 @@ type ListOptions struct {
 // To authenticate you must provide an http.Client that will perform authentication
 // for you with one of the currently supported mechanisms: OAuth or HTTP Basic.
 func NewClient(httpClient *http.Client) *Client {
-	c := &Client{httpClient: httpClient, BaseURL: defaultBaseURL}
+	c := &Client{
+		httpClient: httpClient,
+		BaseURL:    defaultBaseURL,
+	}
 	c.Identity = &IdentityService{client: c}
 	c.Accounts = &AccountsService{client: c}
 	c.Billing = &BillingService{client: c}
@@ -127,16 +130,6 @@ func NewClient(httpClient *http.Client) *Client {
 //	customAgentFlag dnsimple-go/1.0
 func (c *Client) SetUserAgent(ua string) {
 	c.UserAgent = ua
-}
-
-func (c *Client) debugLogf(format string, v ...interface{}) {
-	if c.Debug {
-		if c.DebugLogger != nil {
-			c.DebugLogger.Printf(format, v...)
-		} else {
-			log.Printf(format, v...)
-		}
-	}
 }
 
 // formatUserAgent builds the final user agent to use for HTTP requests.
@@ -195,17 +188,57 @@ func (c *Client) makeRequest(ctx context.Context, method, path string, payload, 
 	if err != nil {
 		return nil, err
 	}
-
-	c.debugLogf("Request (%v): %#v", req.URL, req)
+	logger := c.resolveLogger()
 
 	resp, err := c.request(ctx, req, obj)
 	if err != nil {
+		logger.DebugContext(ctx, "Request",
+			slog.String("method", req.Method),
+			slog.String("url", req.URL.String()),
+			headerAttrs(req.Header),
+		)
 		return nil, err
 	}
-
-	c.debugLogf("Response: %#v", resp)
-
+	//logger.DebugContext(ctx, "Request", reqAttrs...)
+	logger.DebugContext(ctx, "Request",
+		slog.String("method", req.Method),
+		slog.String("url", req.URL.String()),
+		headerAttrs(req.Header),
+	)
+	logger.DebugContext(ctx, "Response",
+		slog.Int("status", resp.StatusCode),
+		slog.String("status_text", resp.Status),
+		headerAttrs(resp.Header),
+	)
 	return resp, nil
+}
+
+func (c *Client) resolveLogger() *slog.Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+
+	if c.Debug {
+		// Backward compat: honour the old Debug flag by enabling debug level
+		handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})
+		return slog.New(handler).With("component", logComponent)
+	}
+
+	return slog.Default().With("component", logComponent)
+}
+
+// headerAttrs converts relevant headers into a slog.Group
+// so all headers are nested under a single "headers" key.
+// Any header present in the  is included automatically, so new
+// API headers appear in logs without requiring code changes.
+func headerAttrs(h http.Header) slog.Attr {
+	var attrs []any
+	for key, vals := range h {
+		attrs = append(attrs, slog.String(key, strings.Join(vals, ", ")))
+	}
+	return slog.Group("headers", attrs...)
 }
 
 // newRequest creates an API request.

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -11,8 +11,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -199,7 +199,7 @@ func (c *Client) makeRequest(ctx context.Context, method, path string, payload, 
 		)
 		return nil, err
 	}
-	//logger.DebugContext(ctx, "Request", reqAttrs...)
+
 	logger.DebugContext(ctx, "Request",
 		slog.String("method", req.Method),
 		slog.String("url", req.URL.String()),
@@ -230,9 +230,7 @@ func (c *Client) resolveLogger() *slog.Logger {
 }
 
 // headerAttrs converts relevant headers into a slog.Group
-// so all headers are nested under a single "headers" key.
-// Any header present in the  is included automatically, so new
-// API headers appear in logs without requiring code changes.
+// so all headers are nested under a "headers" key.
 func headerAttrs(h http.Header) slog.Attr {
 	var attrs []any
 	for key, vals := range h {


### PR DESCRIPTION
In this PR, I've gone ahead with the 3rd approach that was suggested in issue #251 

A client that uses Logrus can do so, 
```go
	lr := logrus.New()
	lr.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})

	clientUsingLogrus := dnsimple.NewClient(http.DefaultClient)
	clientUsingLogrus.Debug = true

	// Here we add the [api] "prefix" as a structured field
	// Every log message from this client will now include prefix=[api]
	clientUsingLogrus.DebugLogger = lr.WithField("prefix", "[api]")

	_, _ = clientUsingLogrus.Identity.Whoami(context.Background())
```

Output:

`INFO[2026-04-13T22:28:27+05:30] Request (https://api.dnsimple.com/v2/whoami): &http.Request{Method:"GET", URL:(*url.URL)(0xc00018e1b0), Proto:"HTTP/1.1", ProtoMajor:1, ProtoMinor:1, Header:http.Header{"Accept":[]string{"application/json"}, "Content-Type":[]string{"application/json"}, "User-Agent":[]string{"dnsimple-go/8.3.0"}}, Body:http.noBody{}, GetBody:(func() (io.ReadCloser, error))(0x628ba0), ContentLength:0, TransferEncoding:[]string(nil), Close:false, Host:"api.dnsimple.com", Form:url.Values(nil), PostForm:url.Values(nil), MultipartForm:(*multipart.Form)(nil), Trailer:http.Header(nil), RemoteAddr:"", RequestURI:"", TLS:(*tls.ConnectionState)(nil), Cancel:(<-chan struct {})(nil), Response:(*http.Response)(nil), Pattern:"", ctx:context.backgroundCtx{emptyCtx:context.emptyCtx{}}, pat:(*http.pattern)(nil), matches:[]string(nil), otherValues:map[string]string(nil)}  prefix="[api]"`