### PR TITLE
API naming

### DIFF
--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -24,7 +24,7 @@ type Domain struct {
 	State          string `json:"state,omitempty"`
 	AutoRenew      bool   `json:"auto_renew,omitempty"`
 	PrivateWhois   bool   `json:"private_whois,omitempty"`
-	TrusteeService bool   `json:"trustee_service,omitempty"`
+	Trustee        bool   `json:"trustee_service,omitempty"`
 	ExpiresAt      string `json:"expires_at,omitempty"`
 	CreatedAt      string `json:"created_at,omitempty"`
 	UpdatedAt      string `json:"updated_at,omitempty"`

--- a/dnsimple/domains.go
+++ b/dnsimple/domains.go
@@ -15,19 +15,19 @@ type DomainsService struct {
 
 // Domain represents a domain in DNSimple.
 type Domain struct {
-	ID             int64  `json:"id,omitempty"`
-	AccountID      int64  `json:"account_id,omitempty"`
-	RegistrantID   int64  `json:"registrant_id,omitempty"`
-	Name           string `json:"name,omitempty"`
-	UnicodeName    string `json:"unicode_name,omitempty"`
-	Token          string `json:"token,omitempty"`
-	State          string `json:"state,omitempty"`
-	AutoRenew      bool   `json:"auto_renew,omitempty"`
-	PrivateWhois   bool   `json:"private_whois,omitempty"`
-	Trustee        bool   `json:"trustee_service,omitempty"`
-	ExpiresAt      string `json:"expires_at,omitempty"`
-	CreatedAt      string `json:"created_at,omitempty"`
-	UpdatedAt      string `json:"updated_at,omitempty"`
+	ID           int64  `json:"id,omitempty"`
+	AccountID    int64  `json:"account_id,omitempty"`
+	RegistrantID int64  `json:"registrant_id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	UnicodeName  string `json:"unicode_name,omitempty"`
+	Token        string `json:"token,omitempty"`
+	State        string `json:"state,omitempty"`
+	AutoRenew    bool   `json:"auto_renew,omitempty"`
+	PrivateWhois bool   `json:"private_whois,omitempty"`
+	Trustee      bool   `json:"trustee_service,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
 func domainPath(accountID string, domainIdentifier string) (path string) {

--- a/dnsimple/domains_test.go
+++ b/dnsimple/domains_test.go
@@ -127,7 +127,7 @@ func TestDomainsService_GetDomain(t *testing.T) {
 		UpdatedAt:    "2020-06-04T19:15:21Z",
 	}
 	assert.Equal(t, wantSingle, domain)
-	assert.False(t, domain.TrusteeService)
+	assert.False(t, domain.Trustee)
 }
 
 func TestDomainsService_DeleteDomain(t *testing.T) {

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -124,7 +124,7 @@ type RegisterDomainInput struct {
 	// Default to true.
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 	// Set to true to enable the trustee service for the domain.
-	Trustee *bool `json:"trustee_service,omitempty"`
+	EnableTrustee *bool `json:"trustee_service,omitempty"`
 	// Required by some TLDs. Use Tlds.GetTldExtendedAttributes() to get the required entries.
 	ExtendedAttributes map[string]string `json:"extended_attributes,omitempty"`
 	// Required as confirmation of the price, only if the domain is premium.
@@ -185,7 +185,7 @@ type TransferDomainInput struct {
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 	// Set to true to enable the trustee service for the domain. An extra cost may apply.
 	// Default to false.
-	Trustee *bool `json:"trustee_service,omitempty"`
+	EnableTrustee *bool `json:"trustee_service,omitempty"`
 	// Required by some TLDs. Use Tlds.GetTldExtendedAttributes() to get the required entries.
 	ExtendedAttributes map[string]string `json:"extended_attributes,omitempty"`
 	// Required as confirmation of the price, only if the domain is premium.

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -44,13 +44,13 @@ func (s *RegistrarService) CheckDomain(ctx context.Context, accountID string, do
 
 // DomainPrice represents the result of a domain prices call.
 type DomainPrice struct {
-	Domain              string   `json:"domain"`
-	Premium             bool     `json:"premium"`
-	RegistrationPrice   float64  `json:"registration_price"`
-	RenewalPrice        float64  `json:"renewal_price"`
-	RestorePrice        float64  `json:"restore_price"`
-	TransferPrice       float64  `json:"transfer_price"`
-	TrusteePrice *float64 `json:"trustee_service_price,omitempty"`
+	Domain            string   `json:"domain"`
+	Premium           bool     `json:"premium"`
+	RegistrationPrice float64  `json:"registration_price"`
+	RenewalPrice      float64  `json:"renewal_price"`
+	RestorePrice      float64  `json:"restore_price"`
+	TransferPrice     float64  `json:"transfer_price"`
+	TrusteePrice      *float64 `json:"trustee_service_price,omitempty"`
 }
 
 // DomainPriceResponse represents a response from an API method that returns a DomainPrice struct.
@@ -77,16 +77,16 @@ func (s *RegistrarService) GetDomainPrices(ctx context.Context, accountID string
 
 // DomainRegistration represents the result of a domain registration call.
 type DomainRegistration struct {
-	ID             int64  `json:"id"`
-	DomainID       int64  `json:"domain_id"`
-	RegistrantID   int64  `json:"registrant_id"`
-	Period         int    `json:"period"`
-	State          string `json:"state"`
-	AutoRenew      bool   `json:"auto_renew"`
-	WhoisPrivacy   bool   `json:"whois_privacy"`
-	Trustee        bool   `json:"trustee_service"`
-	CreatedAt      string `json:"created_at,omitempty"`
-	UpdatedAt      string `json:"updated_at,omitempty"`
+	ID           int64  `json:"id"`
+	DomainID     int64  `json:"domain_id"`
+	RegistrantID int64  `json:"registrant_id"`
+	Period       int    `json:"period"`
+	State        string `json:"state"`
+	AutoRenew    bool   `json:"auto_renew"`
+	WhoisPrivacy bool   `json:"whois_privacy"`
+	Trustee      bool   `json:"trustee_service"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
 // DomainRegistrationResponse represents a response from an API method that results in a domain registration.

--- a/dnsimple/registrar.go
+++ b/dnsimple/registrar.go
@@ -50,7 +50,7 @@ type DomainPrice struct {
 	RenewalPrice        float64  `json:"renewal_price"`
 	RestorePrice        float64  `json:"restore_price"`
 	TransferPrice       float64  `json:"transfer_price"`
-	TrusteeServicePrice *float64 `json:"trustee_service_price,omitempty"`
+	TrusteePrice *float64 `json:"trustee_service_price,omitempty"`
 }
 
 // DomainPriceResponse represents a response from an API method that returns a DomainPrice struct.
@@ -84,7 +84,7 @@ type DomainRegistration struct {
 	State          string `json:"state"`
 	AutoRenew      bool   `json:"auto_renew"`
 	WhoisPrivacy   bool   `json:"whois_privacy"`
-	TrusteeService bool   `json:"trustee_service"`
+	Trustee        bool   `json:"trustee_service"`
 	CreatedAt      string `json:"created_at,omitempty"`
 	UpdatedAt      string `json:"updated_at,omitempty"`
 }
@@ -124,7 +124,7 @@ type RegisterDomainInput struct {
 	// Default to true.
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 	// Set to true to enable the trustee service for the domain.
-	TrusteeService *bool `json:"trustee_service,omitempty"`
+	Trustee *bool `json:"trustee_service,omitempty"`
 	// Required by some TLDs. Use Tlds.GetTldExtendedAttributes() to get the required entries.
 	ExtendedAttributes map[string]string `json:"extended_attributes,omitempty"`
 	// Required as confirmation of the price, only if the domain is premium.
@@ -157,7 +157,7 @@ type DomainTransfer struct {
 	State             string `json:"state"`
 	AutoRenew         bool   `json:"auto_renew"`
 	WhoisPrivacy      bool   `json:"whois_privacy"`
-	TrusteeService    bool   `json:"trustee_service"`
+	Trustee           bool   `json:"trustee_service"`
 	StatusDescription string `json:"status_description"`
 	CreatedAt         string `json:"created_at,omitempty"`
 	UpdatedAt         string `json:"updated_at,omitempty"`
@@ -185,7 +185,7 @@ type TransferDomainInput struct {
 	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
 	// Set to true to enable the trustee service for the domain. An extra cost may apply.
 	// Default to false.
-	TrusteeService *bool `json:"trustee_service,omitempty"`
+	Trustee *bool `json:"trustee_service,omitempty"`
 	// Required by some TLDs. Use Tlds.GetTldExtendedAttributes() to get the required entries.
 	ExtendedAttributes map[string]string `json:"extended_attributes,omitempty"`
 	// Required as confirmation of the price, only if the domain is premium.

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -267,7 +267,7 @@ func TestRegistrarService_TransferDomain_Trustee(t *testing.T) {
 	})
 
 	trustee := true
-	transferRequest := &TransferDomainInput{RegistrantID: 2, AuthCode: "x1y2z3", Trustee: &trustee}
+	transferRequest := &TransferDomainInput{RegistrantID: 2, AuthCode: "x1y2z3", EnableTrustee: &trustee}
 
 	_, err := client.Registrar.TransferDomain(context.Background(), "1010", "example.com", transferRequest)
 

--- a/dnsimple/registrar_test.go
+++ b/dnsimple/registrar_test.go
@@ -55,8 +55,8 @@ func TestRegistrarService_GetDomainPrices(t *testing.T) {
 	assert.Equal(t, float64(20.0), check.RenewalPrice)
 	assert.Equal(t, float64(20.0), check.RestorePrice)
 	assert.Equal(t, float64(20.0), check.TransferPrice)
-	if check.TrusteeServicePrice != nil {
-		assert.Equal(t, float64(20.0), *check.TrusteeServicePrice)
+	if check.TrusteePrice != nil {
+		assert.Equal(t, float64(20.0), *check.TrusteePrice)
 	}
 }
 
@@ -85,7 +85,7 @@ func TestRegistrarService_GetDomainRegistration(t *testing.T) {
 	assert.Equal(t, check.State, "registering")
 	assert.Equal(t, check.AutoRenew, false)
 	assert.Equal(t, check.WhoisPrivacy, false)
-	assert.False(t, check.TrusteeService)
+	assert.False(t, check.Trustee)
 	assert.Equal(t, check.CreatedAt, "2023-01-27T17:44:32Z")
 	assert.Equal(t, check.UpdatedAt, "2023-01-27T17:44:40Z")
 }
@@ -249,7 +249,7 @@ func TestRegistrarService_TransferDomain_ExtendedAttributes(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestRegistrarService_TransferDomain_TrusteeService(t *testing.T) {
+func TestRegistrarService_TransferDomain_Trustee(t *testing.T) {
 	setupMockServer()
 	defer teardownMockServer()
 
@@ -266,8 +266,8 @@ func TestRegistrarService_TransferDomain_TrusteeService(t *testing.T) {
 		_, _ = io.Copy(w, httpResponse.Body)
 	})
 
-	trusteeService := true
-	transferRequest := &TransferDomainInput{RegistrantID: 2, AuthCode: "x1y2z3", TrusteeService: &trusteeService}
+	trustee := true
+	transferRequest := &TransferDomainInput{RegistrantID: 2, AuthCode: "x1y2z3", Trustee: &trustee}
 
 	_, err := client.Registrar.TransferDomain(context.Background(), "1010", "example.com", transferRequest)
 
@@ -318,7 +318,7 @@ func TestRegistrarService_GetDomainTransfer(t *testing.T) {
 		State:             "cancelled",
 		AutoRenew:         false,
 		WhoisPrivacy:      false,
-		TrusteeService:    false,
+		Trustee:           false,
 		StatusDescription: "Canceled by customer",
 		CreatedAt:         "2020-06-05T18:08:00Z",
 		UpdatedAt:         "2020-06-05T18:10:01Z",
@@ -351,7 +351,7 @@ func TestRegistrarService_CancelDomainTransfer(t *testing.T) {
 		State:             "transferring",
 		AutoRenew:         false,
 		WhoisPrivacy:      false,
-		TrusteeService:    false,
+		Trustee:           false,
 		StatusDescription: "",
 		CreatedAt:         "2020-06-05T18:08:00Z",
 		UpdatedAt:         "2020-06-05T18:08:04Z",

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -15,17 +15,17 @@ type TldsService struct {
 
 // Tld represents a TLD in DNSimple.
 type Tld struct {
-	Tld                    string `json:"tld"`
-	TldType                int    `json:"tld_type"`
-	WhoisPrivacy           bool   `json:"whois_privacy"`
-	TrusteeSupported       bool   `json:"trustee_service_enabled"`
-	TrusteeRequired        bool   `json:"trustee_service_required"`
-	AutoRenewOnly          bool   `json:"auto_renew_only"`
-	MinimumRegistration    int    `json:"minimum_registration"`
-	RegistrationEnabled    bool   `json:"registration_enabled"`
-	RenewalEnabled         bool   `json:"renewal_enabled"`
-	TransferEnabled        bool   `json:"transfer_enabled"`
-	DnssecInterfaceType    string `json:"dnssec_interface_type"`
+	Tld                 string `json:"tld"`
+	TldType             int    `json:"tld_type"`
+	WhoisPrivacy        bool   `json:"whois_privacy"`
+	TrusteeSupported    bool   `json:"trustee_service_enabled"`
+	TrusteeRequired     bool   `json:"trustee_service_required"`
+	AutoRenewOnly       bool   `json:"auto_renew_only"`
+	MinimumRegistration int    `json:"minimum_registration"`
+	RegistrationEnabled bool   `json:"registration_enabled"`
+	RenewalEnabled      bool   `json:"renewal_enabled"`
+	TransferEnabled     bool   `json:"transfer_enabled"`
+	DnssecInterfaceType string `json:"dnssec_interface_type"`
 }
 
 // TldExtendedAttribute represents an extended attributes supported or required

--- a/dnsimple/tlds.go
+++ b/dnsimple/tlds.go
@@ -18,8 +18,8 @@ type Tld struct {
 	Tld                    string `json:"tld"`
 	TldType                int    `json:"tld_type"`
 	WhoisPrivacy           bool   `json:"whois_privacy"`
-	TrusteeServiceEnabled  bool   `json:"trustee_service_enabled"`
-	TrusteeServiceRequired bool   `json:"trustee_service_required"`
+	TrusteeSupported       bool   `json:"trustee_service_enabled"`
+	TrusteeRequired        bool   `json:"trustee_service_required"`
 	AutoRenewOnly          bool   `json:"auto_renew_only"`
 	MinimumRegistration    int    `json:"minimum_registration"`
 	RegistrationEnabled    bool   `json:"registration_enabled"`

--- a/dnsimple/tlds_test.go
+++ b/dnsimple/tlds_test.go
@@ -34,8 +34,8 @@ func TestTldsService_ListTlds(t *testing.T) {
 	assert.Equal(t, 1, tlds[0].MinimumRegistration)
 	assert.True(t, tlds[0].RegistrationEnabled)
 	assert.True(t, tlds[0].RenewalEnabled)
-	assert.False(t, tlds[0].TrusteeServiceEnabled)
-	assert.False(t, tlds[0].TrusteeServiceRequired)
+	assert.False(t, tlds[0].TrusteeSupported)
+	assert.False(t, tlds[0].TrusteeRequired)
 	assert.False(t, tlds[0].TransferEnabled)
 }
 
@@ -78,8 +78,8 @@ func TestTldsService_GetTld(t *testing.T) {
 	assert.Equal(t, "com", tld.Tld)
 	assert.Equal(t, 1, tld.TldType)
 	assert.True(t, tld.WhoisPrivacy)
-	assert.False(t, tld.TrusteeServiceEnabled)
-	assert.False(t, tld.TrusteeServiceRequired)
+	assert.False(t, tld.TrusteeSupported)
+	assert.False(t, tld.TrusteeRequired)
 	assert.False(t, tld.AutoRenewOnly)
 	assert.Equal(t, 1, tld.MinimumRegistration)
 	assert.True(t, tld.RegistrationEnabled)


### PR DESCRIPTION
This PR aligns API naming to the existing client experience, ignoring in many cases the format of the payload from the JSON API (which I believe we should rename too for consistency).

Speaking of consistency, while working on this changeset, I found a couple of possible opportunities for a "breaking change" improvement which I will mention separately in the code.