### PR TITLE
Remove deprecated Certificate contact_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `ContactID` field from the `Certificate` struct and from `LetsencryptCertificateAttributes`. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.
+
 ## 8.3.0 - 2026-04-15
 
 ### Added

--- a/dnsimple/certificates.go
+++ b/dnsimple/certificates.go
@@ -15,10 +15,8 @@ type CertificatesService struct {
 
 // Certificate represents a Certificate in DNSimple.
 type Certificate struct {
-	ID       int64 `json:"id,omitempty"`
-	DomainID int64 `json:"domain_id,omitempty"`
-	// Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
-	ContactID           int64    `json:"contact_id,omitempty"`
+	ID                  int64    `json:"id,omitempty"`
+	DomainID            int64    `json:"domain_id,omitempty"`
 	CommonName          string   `json:"common_name,omitempty"`
 	AlternateNames      []string `json:"alternate_names,omitempty"`
 	Years               int      `json:"years,omitempty"`
@@ -64,8 +62,6 @@ type CertificateRenewal struct {
 
 // LetsencryptCertificateAttributes is a set of attributes to purchase a Let's Encrypt certificate.
 type LetsencryptCertificateAttributes struct {
-	// Deprecated: ContactID is deprecated and its value is ignored and will be removed in the next major version.
-	ContactID          int64    `json:"contact_id,omitempty"`
 	Name               string   `json:"name,omitempty"`
 	AutoRenew          bool     `json:"auto_renew,omitempty"`
 	AlternateNames     []string `json:"alternate_names,omitempty"`

--- a/dnsimple/certificates_test.go
+++ b/dnsimple/certificates_test.go
@@ -78,7 +78,6 @@ func TestCertificatesService_GetCertificate(t *testing.T) {
 	wantSingle := &Certificate{
 		ID:                  101967,
 		DomainID:            289333,
-		ContactID:           2511,
 		CommonName:          "www.bingo.pizza",
 		AlternateNames:      []string{},
 		Years:               1,


### PR DESCRIPTION
## Summary

Remove the deprecated `ContactID` field from the `Certificate` struct and from `LetsencryptCertificateAttributes`. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#987

## Test plan

- [x] Existing tests updated to not reference `ContactID`
- [x] Tests pass